### PR TITLE
chore: remove dead code and unused members in FSM and autos

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience1.java
@@ -11,7 +11,6 @@ import com.pedropathing.geometry.Pose;
 import com.pedropathing.paths.PathChain;
 import com.pedropathing.util.Timer;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
-import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 
 import android.content.SharedPreferences;
 
@@ -28,16 +27,14 @@ import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 @Configurable
 @Config
 public class BlueAudience1 extends DarienOpModeFSM {
-    private TelemetryManager panelsTelemetry;   // Panels Telemetry instance
     // follower is inherited from DarienOpModeFSM
     private int pathState;                      // State machine state
     private Paths paths;                        // Paths
-    private Timer pathTimer, opmodeTimer;
+    private Timer pathTimer;
     private boolean shotgunRunning = false;     // Keep shotgun PID running continuously
 
     public static double PATH_POWER_STANDARD = 0.8;
     public static double PATH_POWER_SLOW = 0.4;
-    public static double SHORT_PATH_TIMEOUT = 1.0;
     public static double STANDARD_PATH_TIMEOUT = 2.0;
     public static double LONG_PATH_TIMEOUT = 4.0;
     public static double SHOOT_TRIPLE_TIMEOUT = 4.0;
@@ -55,10 +52,7 @@ public class BlueAudience1 extends DarienOpModeFSM {
 
         // --- PEDRO + TIMERS INIT ---
         pathTimer = new Timer();
-        opmodeTimer = new Timer();
-        opmodeTimer.resetTimer();
-
-        panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
+        TelemetryManager panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
 
         // Starting pose
         follower.setStartingPose(new Pose(57, 8.75, Math.toRadians(90)));
@@ -83,7 +77,6 @@ public class BlueAudience1 extends DarienOpModeFSM {
         waitForStart();
         if (isStopRequested()) return;
 
-        opmodeTimer.resetTimer();
         setPathState(0);
 
         targetGoalId = APRILTAG_ID_GOAL_BLUE;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience2.java
@@ -11,7 +11,6 @@ import com.pedropathing.geometry.Pose;
 import com.pedropathing.paths.PathChain;
 import com.pedropathing.util.Timer;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
-import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 
 import android.content.SharedPreferences;
 
@@ -28,16 +27,14 @@ import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 @Configurable
 @Config
 public class BlueAudience2 extends DarienOpModeFSM {
-    private TelemetryManager panelsTelemetry;   // Panels Telemetry instance
     // follower is inherited from DarienOpModeFSM
     private int pathState;                      // State machine state
     private Paths paths;                        // Paths
-    private Timer pathTimer, opmodeTimer;
+    private Timer pathTimer;
     private boolean shotgunRunning = false;     // Keep shotgun PID running continuously
 
     public static double PATH_POWER_STANDARD = 0.8;
     public static double PATH_POWER_SLOW = 0.4;
-    public static double SHORT_PATH_TIMEOUT = 1.0;
     public static double STANDARD_PATH_TIMEOUT = 2.0;
     public static double LONG_PATH_TIMEOUT = 4.0;
     public static double SHOOT_TRIPLE_TIMEOUT = 4.0;
@@ -53,10 +50,7 @@ public class BlueAudience2 extends DarienOpModeFSM {
 
         // --- PEDRO + TIMERS INIT ---
         pathTimer = new Timer();
-        opmodeTimer = new Timer();
-        opmodeTimer.resetTimer();
-
-        panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
+        TelemetryManager panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
 
         // Starting pose
         follower.setStartingPose(new Pose(57, 8.75, Math.toRadians(90)));
@@ -81,7 +75,6 @@ public class BlueAudience2 extends DarienOpModeFSM {
         waitForStart();
         if (isStopRequested()) return;
 
-        opmodeTimer.resetTimer();
         setPathState(0);
 
         targetGoalId = APRILTAG_ID_GOAL_BLUE;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide1.java
@@ -5,7 +5,6 @@ import com.bylazar.configurables.annotations.Configurable;
 import com.bylazar.telemetry.PanelsTelemetry;
 import com.bylazar.telemetry.TelemetryManager;
 import com.pedropathing.follower.Follower;
-import com.pedropathing.geometry.BezierCurve;
 import com.pedropathing.geometry.BezierLine;
 import com.pedropathing.geometry.Pose;
 import com.pedropathing.paths.PathChain;
@@ -28,11 +27,10 @@ import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 @Configurable
 public class BlueGoalSide1 extends DarienOpModeFSM {
 
-    private TelemetryManager panelsTelemetry;   // Panels Telemetry instance
     // follower is inherited from DarienOpModeFSM
     private int pathState;                      // State machine state
     private Paths paths;                        // Paths
-    private Timer pathTimer, opmodeTimer;
+    private Timer pathTimer;
     private boolean shotgunRunning = false;     // Keep shotgun PID running continuously
 
     public static double STARTING_POSE_X = 33;
@@ -40,7 +38,6 @@ public class BlueGoalSide1 extends DarienOpModeFSM {
     public static double STARTING_POSE_H_DEG = 180;
     public static double PATH_POWER_STANDARD = 0.8;
     public static double PATH_POWER_SLOW = 0.4;
-    public static double SHORT_PATH_TIMEOUT = 1.0;
     public static double STANDARD_PATH_TIMEOUT = 2.0;
     public static double LONG_PATH_TIMEOUT = 4.0;
     public static double SHOOT_TRIPLE_TIMEOUT = 4.0;
@@ -57,10 +54,7 @@ public class BlueGoalSide1 extends DarienOpModeFSM {
 
         // --- PEDRO + TIMERS INIT ---
         pathTimer = new Timer();
-        opmodeTimer = new Timer();
-        opmodeTimer.resetTimer();
-
-        panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
+        TelemetryManager panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
 
         // Starting pose
         follower.setStartingPose(new Pose(STARTING_POSE_X, STARTING_POSE_Y, Math.toRadians(STARTING_POSE_H_DEG)));
@@ -85,7 +79,6 @@ public class BlueGoalSide1 extends DarienOpModeFSM {
         waitForStart();
         if (isStopRequested()) return;
 
-        opmodeTimer.resetTimer();
         setPathState(0);
 
         targetGoalId = APRILTAG_ID_GOAL_BLUE;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide2.java
@@ -28,11 +28,10 @@ import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 @Configurable
 public class BlueGoalSide2 extends DarienOpModeFSM {
 
-    private TelemetryManager panelsTelemetry;   // Panels Telemetry instance
     // follower is inherited from DarienOpModeFSM
     private int pathState;                      // State machine state
     private Paths paths;                        // Paths
-    private Timer pathTimer, opmodeTimer;
+    private Timer pathTimer;
     private boolean shotgunRunning = false;     // Keep shotgun PID running continuously
 
     public static double STARTING_POSE_X = 33;
@@ -40,7 +39,6 @@ public class BlueGoalSide2 extends DarienOpModeFSM {
     public static double STARTING_POSE_H_DEG = 180;
     public static double PATH_POWER_STANDARD = 0.8;
     public static double PATH_POWER_SLOW = 0.4;
-    public static double SHORT_PATH_TIMEOUT = 1.0;
     public static double STANDARD_PATH_TIMEOUT = 2.0;
     public static double LONG_PATH_TIMEOUT = 4.0;
     public static double SHOOT_TRIPLE_TIMEOUT = 4.0;
@@ -55,10 +53,7 @@ public class BlueGoalSide2 extends DarienOpModeFSM {
 
         // --- PEDRO + TIMERS INIT ---
         pathTimer = new Timer();
-        opmodeTimer = new Timer();
-        opmodeTimer.resetTimer();
-
-        panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
+        TelemetryManager panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
 
         // Starting pose
         follower.setStartingPose(new Pose(STARTING_POSE_X, STARTING_POSE_Y, Math.toRadians(STARTING_POSE_H_DEG)));
@@ -83,7 +78,6 @@ public class BlueGoalSide2 extends DarienOpModeFSM {
         waitForStart();
         if (isStopRequested()) return;
 
-        opmodeTimer.resetTimer();
         setPathState(0);
 
         targetGoalId = APRILTAG_ID_GOAL_BLUE;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide3.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide3.java
@@ -5,7 +5,6 @@ import com.bylazar.configurables.annotations.Configurable;
 import com.bylazar.telemetry.PanelsTelemetry;
 import com.bylazar.telemetry.TelemetryManager;
 import com.pedropathing.follower.Follower;
-import com.pedropathing.geometry.BezierCurve;
 import com.pedropathing.geometry.BezierLine;
 import com.pedropathing.geometry.Pose;
 import com.pedropathing.paths.PathChain;
@@ -30,11 +29,10 @@ import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 @Configurable
 public class BlueGoalSide3 extends DarienOpModeFSM {
 
-    private TelemetryManager panelsTelemetry;   // Panels Telemetry instance
     // follower is inherited from DarienOpModeFSM
     private int pathState;                      // State machine state
     private Paths paths;                        // Paths
-    private Timer pathTimer, opmodeTimer;
+    private Timer pathTimer;
 
     public static double PATH_POWER_STANDARD = 0.8;
     public static double PATH_POWER_SLOW = 0.4;
@@ -51,10 +49,7 @@ public class BlueGoalSide3 extends DarienOpModeFSM {
 
         // --- PEDRO + TIMERS INIT ---
         pathTimer = new Timer();
-        opmodeTimer = new Timer();
-        opmodeTimer.resetTimer();
-
-        panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
+        TelemetryManager panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
 
         // Starting pose
         follower.setStartingPose(new Pose(57, 135, Math.toRadians(180)));
@@ -78,7 +73,6 @@ public class BlueGoalSide3 extends DarienOpModeFSM {
         waitForStart();
         if (isStopRequested()) return;
 
-        opmodeTimer.resetTimer();
         setPathState(0);
 
         targetGoalId = APRILTAG_ID_GOAL_BLUE;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience1.java
@@ -27,16 +27,14 @@ import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 @Configurable
 @Config
 public class RedAudience1 extends DarienOpModeFSM {
-    private TelemetryManager panelsTelemetry;   // Panels Telemetry instance
     // follower is inherited from DarienOpModeFSM
     private int pathState;                      // State machine state
     private Paths paths;                        // Paths
-    private Timer pathTimer, opmodeTimer;
+    private Timer pathTimer;
     private boolean shotgunRunning = false;     // Keep shotgun PID running continuously
 
     public static double PATH_POWER_STANDARD = 0.8;
     public static double PATH_POWER_SLOW = 0.4;
-    public static double SHORT_PATH_TIMEOUT = 1.0;
     public static double STANDARD_PATH_TIMEOUT = 2.0;
     public static double LONG_PATH_TIMEOUT = 4.0;
     public static double SHOOT_TRIPLE_TIMEOUT = 4.0;
@@ -54,10 +52,7 @@ public class RedAudience1 extends DarienOpModeFSM {
 
         // --- PEDRO + TIMERS INIT ---
         pathTimer = new Timer();
-        opmodeTimer = new Timer();
-        opmodeTimer.resetTimer();
-
-        panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
+        TelemetryManager panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
 
         // Starting pose
         follower.setStartingPose(new Pose(87, 8.75, Math.toRadians(90)));
@@ -82,7 +77,6 @@ public class RedAudience1 extends DarienOpModeFSM {
         waitForStart();
         if (isStopRequested()) return;
 
-        opmodeTimer.resetTimer();
         setPathState(0);
 
         targetGoalId = APRILTAG_ID_GOAL_RED;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience2.java
@@ -26,16 +26,14 @@ import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 @Configurable
 @Config
 public class RedAudience2 extends DarienOpModeFSM {
-    private TelemetryManager panelsTelemetry;   // Panels Telemetry instance
     // follower is inherited from DarienOpModeFSM
     private int pathState;                      // State machine state
     private Paths paths;                        // Paths
-    private Timer pathTimer, opmodeTimer;
+    private Timer pathTimer;
     private boolean shotgunRunning = false;     // Keep shotgun PID running continuously
 
     public static double PATH_POWER_STANDARD = 0.8;
     public static double PATH_POWER_SLOW = 0.4;
-    public static double SHORT_PATH_TIMEOUT = 1.0;
     public static double STANDARD_PATH_TIMEOUT = 2.0;
     public static double LONG_PATH_TIMEOUT = 4.0;
     public static double SHOOT_TRIPLE_TIMEOUT = 4.0;
@@ -51,10 +49,7 @@ public class RedAudience2 extends DarienOpModeFSM {
 
         // --- PEDRO + TIMERS INIT ---
         pathTimer = new Timer();
-        opmodeTimer = new Timer();
-        opmodeTimer.resetTimer();
-
-        panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
+        TelemetryManager panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
 
         // Starting pose
         follower.setStartingPose(new Pose(87, 8.75, Math.toRadians(90)));
@@ -79,7 +74,6 @@ public class RedAudience2 extends DarienOpModeFSM {
         waitForStart();
         if (isStopRequested()) return;
 
-        opmodeTimer.resetTimer();
         setPathState(0);
 
         targetGoalId = APRILTAG_ID_GOAL_RED;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience3.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience3.java
@@ -24,11 +24,10 @@ import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 @Configurable
 @Config
 public class RedAudience3 extends DarienOpModeFSM {
-    private TelemetryManager panelsTelemetry; // Panels Telemetry instance
     // follower is inherited from DarienOpModeFSM
     private int pathState;                      // State machine state
     private Paths paths;                        // Paths
-    private Timer pathTimer, opmodeTimer;
+    private Timer pathTimer;
 
     public static double PATH_POWER_STANDARD = 1;
     public static double PATH_POWER_SLOW = 0.25;
@@ -48,10 +47,7 @@ public class RedAudience3 extends DarienOpModeFSM {
 
         // --- PEDRO + TIMERS INIT ---
         pathTimer = new Timer();
-        opmodeTimer = new Timer();
-        opmodeTimer.resetTimer();
-
-        panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
+        TelemetryManager panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
 
         // Starting pose
         follower.setStartingPose(new Pose(88, 9, Math.toRadians(90)));
@@ -74,7 +70,6 @@ public class RedAudience3 extends DarienOpModeFSM {
         waitForStart();
         if (isStopRequested()) return;
 
-        opmodeTimer.resetTimer();
         setPathState(0);
 
         targetGoalId = APRILTAG_ID_GOAL_RED;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide1.java
@@ -5,7 +5,6 @@ import com.bylazar.configurables.annotations.Configurable;
 import com.bylazar.telemetry.PanelsTelemetry;
 import com.bylazar.telemetry.TelemetryManager;
 import com.pedropathing.follower.Follower;
-import com.pedropathing.geometry.BezierCurve;
 import com.pedropathing.geometry.BezierLine;
 import com.pedropathing.geometry.Pose;
 import com.pedropathing.paths.PathChain;
@@ -28,11 +27,10 @@ import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 @Configurable
 public class RedGoalSide1 extends DarienOpModeFSM {
 
-    private TelemetryManager panelsTelemetry;   // Panels Telemetry instance
     // follower is inherited from DarienOpModeFSM
     private int pathState;                      // State machine state
     private Paths paths;                        // Paths
-    private Timer pathTimer, opmodeTimer;
+    private Timer pathTimer;
     private boolean shotgunRunning = false;     // Keep shotgun PID running continuously
 
     public static double STARTING_POSE_X = 111;
@@ -40,10 +38,8 @@ public class RedGoalSide1 extends DarienOpModeFSM {
     public static double STARTING_POSE_H_DEG = 0;
     public static double PATH_POWER_STANDARD = 0.8;
     public static double PATH_POWER_SLOW = 0.4;
-    public static double SHORT_PATH_TIMEOUT = 1.0;
     public static double STANDARD_PATH_TIMEOUT = 2.0;
     public static double LONG_PATH_TIMEOUT = 4.0;
-    public static double SHOOT_TRIPLE_TIMEOUT = 4.0;
     public static double SHOOT_TRIPLE_TIME_MIN = 5.0;
     public static double SHOOT_TRIPLE_TIME_MAX = 7.0;
     public double targetGoalX = DarienOpModeFSM.GOAL_RED_X;
@@ -57,10 +53,8 @@ public class RedGoalSide1 extends DarienOpModeFSM {
 
         // --- PEDRO + TIMERS INIT ---
         pathTimer = new Timer();
-        opmodeTimer = new Timer();
-        opmodeTimer.resetTimer();
 
-        panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
+        TelemetryManager panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
 
         // Starting pose
         follower.setStartingPose(new Pose(STARTING_POSE_X, STARTING_POSE_Y, Math.toRadians(STARTING_POSE_H_DEG)));
@@ -85,7 +79,6 @@ public class RedGoalSide1 extends DarienOpModeFSM {
         waitForStart();
         if (isStopRequested()) return;
 
-        opmodeTimer.resetTimer();
         setPathState(0);
 
         targetGoalId = APRILTAG_ID_GOAL_RED;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide2.java
@@ -29,11 +29,10 @@ import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 @Configurable
 public class RedGoalSide2 extends DarienOpModeFSM {
 
-    private TelemetryManager panelsTelemetry;   // Panels Telemetry instance
     // follower is inherited from DarienOpModeFSM
     private int pathState;                      // State machine state
     private Paths paths;                        // Paths
-    private Timer pathTimer, opmodeTimer;
+    private Timer pathTimer;
     private boolean shotgunRunning = false;     // Keep shotgun PID running continuously
 
     public static double STARTING_POSE_X = 111;
@@ -41,7 +40,6 @@ public class RedGoalSide2 extends DarienOpModeFSM {
     public static double STARTING_POSE_H_DEG = 0;
     public static double PATH_POWER_STANDARD = 0.8;
     public static double PATH_POWER_SLOW = 0.4;
-    public static double SHORT_PATH_TIMEOUT = 1.0;
     public static double STANDARD_PATH_TIMEOUT = 2.0;
     public static double LONG_PATH_TIMEOUT = 4.0;
     public static double SHOOT_TRIPLE_TIMEOUT = 4.0;
@@ -56,10 +54,8 @@ public class RedGoalSide2 extends DarienOpModeFSM {
 
         // --- PEDRO + TIMERS INIT ---
         pathTimer = new Timer();
-        opmodeTimer = new Timer();
-        opmodeTimer.resetTimer();
 
-        panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
+        TelemetryManager panelsTelemetry = PanelsTelemetry.INSTANCE.getTelemetry();
 
         // Starting pose
         follower.setStartingPose(new Pose(STARTING_POSE_X, STARTING_POSE_Y, Math.toRadians(STARTING_POSE_H_DEG)));
@@ -84,7 +80,6 @@ public class RedGoalSide2 extends DarienOpModeFSM {
         waitForStart();
         if (isStopRequested()) return;
 
-        opmodeTimer.resetTimer();
         setPathState(0);
 
         targetGoalId = APRILTAG_ID_GOAL_RED;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/DarienOpModeFSM.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/DarienOpModeFSM.java
@@ -5,16 +5,11 @@ import com.acmerobotics.dashboard.FtcDashboard;
 import com.acmerobotics.dashboard.telemetry.TelemetryPacket;
 import com.bylazar.configurables.annotations.Configurable;
 import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
-import com.qualcomm.robotcore.hardware.CRServo;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
-import com.qualcomm.robotcore.hardware.DigitalChannel;
-import com.qualcomm.robotcore.hardware.NormalizedColorSensor;
-import com.qualcomm.robotcore.hardware.Servo;
 
 import com.pedropathing.follower.Follower;
 
-import org.firstinspires.ftc.robotcore.external.hardware.camera.WebcamName;
 import org.firstinspires.ftc.robotcore.external.hardware.camera.controls.ExposureControl;
 import org.firstinspires.ftc.robotcore.external.hardware.camera.controls.GainControl;
 import org.firstinspires.ftc.teamcode.pedroPathing.Constants;
@@ -237,12 +232,6 @@ public abstract class DarienOpModeFSM extends LinearOpMode {
         // Create the AprilTag processor the easy way.
         aprilTag = AprilTagProcessor.easyCreateWithDefaults();
 
-        // Create the vision portal the easy way.
-        /*
-        visionPortal = VisionPortal.easyCreateWithDefaults(
-                hardwareMap.get(WebcamName.class, "Webcam 1"), aprilTag)
-                ;
-         */
 
         // Set manual exposure and gain to reduce motion blur and improve detection at distance
         // This is especially important for detecting AprilTags from far positions

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/ShootArtifactFSM.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/ShootArtifactFSM.java
@@ -18,11 +18,9 @@ public class ShootArtifactFSM {
 
     private ShootingStage shootingStage = ShootingStage.IDLE;
     private double shootingStartTime = 0;
-    private double shootingPower = 0;
 
     // Timings (seconds)
     public static double GATE_OPEN_DELAY = .35;
-    public static double GATE_CLOSE_DELAY = .25;
     public static double SPINUP_DELAY = 0.0;    // shotgun running before shooting artifact
 
     public ShootArtifactFSM(DarienOpModeFSM opMode) {
@@ -31,7 +29,6 @@ public class ShootArtifactFSM {
 
     // Call this to begin shooting
     public void startShooting(double shootingPower) {
-        this.shootingPower = shootingPower;
         if (!ejectionMotorsControlledByPattern) {
             shotGun(shootingPower);
         }
@@ -66,18 +63,6 @@ public class ShootArtifactFSM {
                     shootingStartTime = currentTime; // Reset timer for next stage
                 }
                 break;
-/*
-            case FINISHED:
-                //opMode.Elevator.setPosition(DarienOpModeFSM.GATE_CLOSED);
-                if (currentTime - shootingStartTime >= ELEVATOR_DOWN_DELAY) {
-                    if (!ejectionMotorsControlledByPattern) {
-                        shotGunStop();
-                    }
-                    shootingStage = ShootingStage.FINISHED;
-                }
-                break;
-
- */
             case IDLE:
             default:
                 break;
@@ -96,19 +81,10 @@ public class ShootArtifactFSM {
 
     public void shotGun(double power) {
         //opMode.ejectionMotor.setPower(opMode.getVoltageAdjustedMotorPower(power));
-        if (power == opMode.SHOT_GUN_POWER_UP) {
-            shotGunRPM(opMode.SHOT_GUN_POWER_UP_RPM_AUTO);
-        } else if (power == opMode.SHOT_GUN_POWER_UP_FAR) {
-            shotGunRPM(opMode.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
-        }
-    }
-
-    public void shotGunTeleop(double power) {
-        //opMode.ejectionMotor.setPower(opMode.getVoltageAdjustedMotorPower(power));
-        if (power == opMode.SHOT_GUN_POWER_UP) {
-            shotGunRPM(opMode.SHOT_GUN_POWER_UP_RPM);
-        } else if (power == opMode.SHOT_GUN_POWER_UP_FAR) {
-            shotGunRPM(opMode.SHOT_GUN_POWER_UP_FAR_RPM_TELEOP);
+        if (power == DarienOpModeFSM.SHOT_GUN_POWER_UP) {
+            shotGunRPM(DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO);
+        } else if (power == DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR) {
+            shotGunRPM(DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
         }
     }
 
@@ -116,16 +92,9 @@ public class ShootArtifactFSM {
         opMode.ejectionMotor.setVelocity(opMode.getTicksPerSecond(RPM));
     }
 
-    public void shotGunStop() {
-        opMode.ejectionMotor.setPower(0);
-    }
-
     public void setEjectionMotorsControlledByPattern(boolean controlled) {
         this.ejectionMotorsControlledByPattern = controlled;
     }
 
-    public ShootingStage getShootingStage() {
-        return shootingStage;
-    }
 
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/TeleOpFSM.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/TeleOpFSM.java
@@ -18,9 +18,8 @@ import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import org.firstinspires.ftc.vision.apriltag.AprilTagDetection;
 
 import com.bylazar.configurables.annotations.Configurable;
-import com.bylazar.telemetry.TelemetryManager;
-import com.qualcomm.robotcore.hardware.DistanceSensor;
 
+import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
 
 import org.firstinspires.ftc.robotcore.internal.system.AppUtil;
@@ -31,28 +30,22 @@ import org.firstinspires.ftc.robotcore.internal.system.AppUtil;
 public class TeleOpFSM extends DarienOpModeFSM {
 
     // INSTANCES
-    private TelemetryManager panelsTelemetry;   // Panels Telemetry instance
     // follower is inherited from DarienOpModeFSM
     private GoBildaPinpointDriver odo;          // Pinpoint odometry driver for position reset
 
     // TUNING CONSTANTS
-    public static double SHOT_TIMEOUT = 2.0; // seconds
     public static double ROTATION_SCALE = 0.5;
     public static double SPEED_SCALE = 1.0;
     public static double SPEED_SCALE_TURN = 0.8;
     public static double INPUT_EXPONENT = 3.0; // 1.0=linear, 2.0=squared, 3.0=cubed (preserves sign)
 
     // VARIABLES
-    private double shotStartTime;
-    //private boolean shotStarted = false;
     private boolean isReadingAprilTag = false;
 
     private ShotgunPowerLevel shotgunPowerLatch = ShotgunPowerLevel.OFF;
 
 
     // Turret fallback tracking
-    private double lastCameraDetectionTime = 0;  // Timestamp of last successful camera detection
-
     // AUTO-PARK STATE
     private boolean isAutoParking = false;
     private double autoParkStartTime = 0;
@@ -61,18 +54,10 @@ public class TeleOpFSM extends DarienOpModeFSM {
 
     // AUTOMATIC TURRET CONTROLS BASED ON CAMERA APRILTAG DETECTION
     AprilTagDetection detection;
-    double yaw, range; // Stores detection.ftcPose.yaw
-    double currentHeadingDeg;
-    double relativeHeadingDeg; // Camera-relative bearing to AprilTag (degrees)
-    double targetServoPos = Double.NaN; // Convert heading → servo position
     double rawBearingDeg; // Stores detection.ftcPose.bearing;
 
     double robotX, robotY, robotHeadingRadians;
 
-    // cameraOffsetX < 0 if camera is mounted on the LEFT
-// public static double cameraOffsetX = 0.105; // in centimeter, positive is right, negative is left
-    double correctedBearingRad;
-    double correctedBearingDeg;
     boolean isCalculatingTurretTargetPosition = false;
 
     int targetGoalTagId;
@@ -89,9 +74,9 @@ public class TeleOpFSM extends DarienOpModeFSM {
     }
 
 
+    @SuppressLint("DefaultLocale")
     @Override
     public void runOpMode() throws InterruptedException {
-        float gain = 2;
         initControls();
         tp = new TelemetryPacket();
         dash = FtcDashboard.getInstance();
@@ -381,25 +366,6 @@ public class TeleOpFSM extends DarienOpModeFSM {
                 startReadingGoalId();
             }
 
-            /* NOT BEING USED
-            // -----------------
-            // SHOOTING MACRO (dpad_down) — start a timed single-shot sequence
-            // -----------------
-            if (gamepad2.dpad_down && !shotStarted) {
-                ShootingFSM.PowerLevel power = (gamepad2.right_stick_y < -0.05)
-                        ? ShootingFSM.PowerLevel.FAR
-                        : ShootingFSM.PowerLevel.CLOSE;
-                shootingFSM.start(getRuntime(), power);
-                shotStartTime = getRuntime();
-                shotStarted = true;
-            }
-            if (shotStarted) {
-                if (shootingFSM.isDone() || getRuntime() - shotStartTime >= SHOT_TIMEOUT) {
-                    shootingFSM.reset();
-                    shotStarted = false;
-                }
-            }
-             */
 
 
             // Get current robot pose from follower


### PR DESCRIPTION
This pull request refactors several autonomous OpMode classes to simplify timer and telemetry initialization and remove unused code. The main focus is on cleaning up redundant member variables and streamlining how telemetry is accessed within the OpModes.

Key changes include:

**Timer and Telemetry Initialization Cleanup:**
- Removed the `opmodeTimer` member variable and its initialization/reset logic from all affected OpMode classes. Now, only the `pathTimer` is kept as a member variable, and `panelsTelemetry` is initialized as a local variable within `runOpMode()` instead of as a class member. [[1]](diffhunk://#diff-365263b42c6f343ce08c25b8b1bedfd7cb0fa07c9a4cef26b414991c24f1835eL31-L40) [[2]](diffhunk://#diff-a48eb0598752a92fc08b03020d2dd7219cf607af4fba12bd32bc9c52560da19aL31-L40) [[3]](diffhunk://#diff-0dc7fccf7ecc84748488db692d206bc25ba1950d50c53affa2e5f415d03f2605L31-L43) [[4]](diffhunk://#diff-72d9e168caa61375d3402fbe84e14c0ecf153f4a4b6fe165a3fd00a17960e3e2L31-L43) [[5]](diffhunk://#diff-3549683f11defe3707f47cbc6ffa15c6455ff8e904e504793ec254669248a018L33-R35) [[6]](diffhunk://#diff-672d2e3fadc41b9ca3c6e7eadebe0efba6bf6b9ec83158650ec13ab2dabd5e05L30-L39) [[7]](diffhunk://#diff-f8cfda50b49f90d1814581c23909d873175cafe778f6ab7030416874b0b4224cL29-L38) [[8]](diffhunk://#diff-9af4f52a515c3eae4e182f15ca6a7e35ce0aa57e587a06d903088c96db02dd65L27-R30)

- Removed all calls to `opmodeTimer.resetTimer()` and related logic from the OpModes' `runOpMode()` methods. [[1]](diffhunk://#diff-365263b42c6f343ce08c25b8b1bedfd7cb0fa07c9a4cef26b414991c24f1835eL58-R55) [[2]](diffhunk://#diff-a48eb0598752a92fc08b03020d2dd7219cf607af4fba12bd32bc9c52560da19aL56-R53) [[3]](diffhunk://#diff-0dc7fccf7ecc84748488db692d206bc25ba1950d50c53affa2e5f415d03f2605L60-R57) [[4]](diffhunk://#diff-72d9e168caa61375d3402fbe84e14c0ecf153f4a4b6fe165a3fd00a17960e3e2L58-R56) [[5]](diffhunk://#diff-3549683f11defe3707f47cbc6ffa15c6455ff8e904e504793ec254669248a018L54-R52) [[6]](diffhunk://#diff-672d2e3fadc41b9ca3c6e7eadebe0efba6bf6b9ec83158650ec13ab2dabd5e05L57-R55) [[7]](diffhunk://#diff-f8cfda50b49f90d1814581c23909d873175cafe778f6ab7030416874b0b4224cL54-R52) [[8]](diffhunk://#diff-9af4f52a515c3eae4e182f15ca6a7e35ce0aa57e587a06d903088c96db02dd65L51-R50)

**Codebase Simplification:**
- Removed unused imports, such as `com.pedropathing.geometry.BezierCurve` and `com.qualcomm.robotcore.eventloop.opmode.Disabled`, from several files to reduce clutter. [[1]](diffhunk://#diff-0dc7fccf7ecc84748488db692d206bc25ba1950d50c53affa2e5f415d03f2605L8) [[2]](diffhunk://#diff-3549683f11defe3707f47cbc6ffa15c6455ff8e904e504793ec254669248a018L8) [[3]](diffhunk://#diff-5d4d733e771c6a089332539da080c6b0c8cbeba427bbaf9d851120f4829fc689L8) [[4]](diffhunk://#diff-365263b42c6f343ce08c25b8b1bedfd7cb0fa07c9a4cef26b414991c24f1835eL14) [[5]](diffhunk://#diff-a48eb0598752a92fc08b03020d2dd7219cf607af4fba12bd32bc9c52560da19aL14)

**Constants Cleanup:**
- Removed the unused `SHORT_PATH_TIMEOUT` constant from all OpMode classes. [[1]](diffhunk://#diff-365263b42c6f343ce08c25b8b1bedfd7cb0fa07c9a4cef26b414991c24f1835eL31-L40) [[2]](diffhunk://#diff-a48eb0598752a92fc08b03020d2dd7219cf607af4fba12bd32bc9c52560da19aL31-L40) [[3]](diffhunk://#diff-0dc7fccf7ecc84748488db692d206bc25ba1950d50c53affa2e5f415d03f2605L31-L43) [[4]](diffhunk://#diff-72d9e168caa61375d3402fbe84e14c0ecf153f4a4b6fe165a3fd00a17960e3e2L31-L43) [[5]](diffhunk://#diff-672d2e3fadc41b9ca3c6e7eadebe0efba6bf6b9ec83158650ec13ab2dabd5e05L30-L39) [[6]](diffhunk://#diff-f8cfda50b49f90d1814581c23909d873175cafe778f6ab7030416874b0b4224cL29-L38)

**Consistency Improvements:**
- Ensured all OpModes now consistently initialize `panelsTelemetry` locally and only keep necessary timers as class members, improving code readability and maintainability. [[1]](diffhunk://#diff-365263b42c6f343ce08c25b8b1bedfd7cb0fa07c9a4cef26b414991c24f1835eL58-R55) [[2]](diffhunk://#diff-a48eb0598752a92fc08b03020d2dd7219cf607af4fba12bd32bc9c52560da19aL56-R53) [[3]](diffhunk://#diff-0dc7fccf7ecc84748488db692d206bc25ba1950d50c53affa2e5f415d03f2605L60-R57) [[4]](diffhunk://#diff-72d9e168caa61375d3402fbe84e14c0ecf153f4a4b6fe165a3fd00a17960e3e2L58-R56) [[5]](diffhunk://#diff-3549683f11defe3707f47cbc6ffa15c6455ff8e904e504793ec254669248a018L54-R52) [[6]](diffhunk://#diff-672d2e3fadc41b9ca3c6e7eadebe0efba6bf6b9ec83158650ec13ab2dabd5e05L57-R55) [[7]](diffhunk://#diff-f8cfda50b49f90d1814581c23909d873175cafe778f6ab7030416874b0b4224cL54-R52) [[8]](diffhunk://#diff-9af4f52a515c3eae4e182f15ca6a7e35ce0aa57e587a06d903088c96db02dd65L51-R50)

**Minor Cleanups:**
- Minor formatting and comment adjustments to reflect the removal of member variables and unused code. (throughout all affected files)

These changes make the autonomous OpMode code cleaner, easier to maintain, and less error-prone by removing unnecessary state and improving initialization patterns.