### PR TITLE
refactor(p0): add shared trace telemetry schema across TeleOp and all autos

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/docs/README.md
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/docs/README.md
@@ -5,6 +5,7 @@ This folder contains architecture notes, refactor planning, and issue-specific t
 ## Refactor planning
 - [`refactoring-plan-2026-05.md`](refactoring-plan-2026-05.md) - phased architecture refactor plan.
 - [`refactor-branch-pr-checklist.md`](refactor-branch-pr-checklist.md) - branch strategy and PR execution checklist.
+- [`TRACE_TELEMETRY_SCHEMA.md`](TRACE_TELEMETRY_SCHEMA.md) - shared TeleOp/auto trace keys used for P0 baseline validation.
 
 ## Vision/AprilTag notes
 - [`APRILTAG_CAMERA_OPTIMIZATION.md`](APRILTAG_CAMERA_OPTIMIZATION.md) - exposure/gain tuning workflow and camera guidance.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/docs/TRACE_TELEMETRY_SCHEMA.md
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/docs/TRACE_TELEMETRY_SCHEMA.md
@@ -1,0 +1,21 @@
+# Trace Telemetry Schema (P0 Baseline)
+
+This document defines the shared trace keys emitted by `TeleOpFSM`, `RedGoalSide1`, and `RedGoalSide2` during the refactor baseline phase.
+
+## Keys
+
+- `TRACE/Phase` - high-level loop context (for example `TeleOp`, `Auto-RedGoalSide1`).
+- `TRACE/State` - current state identifier (`DRIVER_CONTROL`, `AUTO_PARK`, or auto `pathState`).
+- `TRACE/RuntimeSec` - OpMode runtime in seconds.
+- `TRACE/StateTimerSec` - elapsed seconds in the current state context.
+- `TRACE/Pose` - live follower pose as `x`, `y`, and heading in degrees.
+- `TRACE/TurretMode` - current turret FSM mode.
+- `TRACE/ShooterMode` - current shooting power mode (`MANUAL` or `ODOMETRY`).
+- `TRACE/ShooterStage` - current shooting FSM stage.
+
+## Notes
+
+- Runtime pose values are sourced from `follower.getPose()`.
+- This schema is intended for no-behavior-change validation while refactoring internals.
+- Additional keys can be appended in later phases, but existing keys should remain stable for log comparisons.
+

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience1.java
@@ -121,6 +121,7 @@ public class BlueAudience1 extends DarienOpModeFSM {
             panelsTelemetry.addData("Heading", follower.getPose().getHeading());
             panelsTelemetry.addData("Alliance Color", "BLUE");
             telemetry.addData("Alliance Color Saved", "BLUE");
+            addTraceTelemetry("Auto-BlueAudience1", Integer.toString(pathState), pathTimer.getElapsedTimeSeconds());
             displayRpmTelemetry();
             panelsTelemetry.update(telemetry);
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience2.java
@@ -119,6 +119,7 @@ public class BlueAudience2 extends DarienOpModeFSM {
             panelsTelemetry.addData("Heading", follower.getPose().getHeading());
             panelsTelemetry.addData("Alliance Color", "BLUE");
             telemetry.addData("Alliance Color Saved", "BLUE");
+            addTraceTelemetry("Auto-BlueAudience2", Integer.toString(pathState), pathTimer.getElapsedTimeSeconds());
             displayRpmTelemetry();
             panelsTelemetry.update(telemetry);
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide1.java
@@ -123,6 +123,7 @@ public class BlueGoalSide1 extends DarienOpModeFSM {
             panelsTelemetry.addData("Heading", follower.getPose().getHeading());
             panelsTelemetry.addData("Alliance Color", "BLUE");
             telemetry.addData("Alliance Color Saved", "BLUE");
+            addTraceTelemetry("Auto-BlueGoalSide1", Integer.toString(pathState), pathTimer.getElapsedTimeSeconds());
             displayRpmTelemetry();
             panelsTelemetry.update(telemetry);
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide2.java
@@ -122,6 +122,7 @@ public class BlueGoalSide2 extends DarienOpModeFSM {
             panelsTelemetry.addData("Heading", follower.getPose().getHeading());
             panelsTelemetry.addData("Alliance Color", "BLUE");
             telemetry.addData("Alliance Color Saved", "BLUE");
+            addTraceTelemetry("Auto-BlueGoalSide2", Integer.toString(pathState), pathTimer.getElapsedTimeSeconds());
             displayRpmTelemetry();
             panelsTelemetry.update(telemetry);
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide3.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide3.java
@@ -112,6 +112,7 @@ public class BlueGoalSide3 extends DarienOpModeFSM {
             panelsTelemetry.addData("Heading", follower.getPose().getHeading());
             panelsTelemetry.addData("Alliance Color", "BLUE");
             telemetry.addData("Alliance Color Saved", "BLUE");
+            addTraceTelemetry("Auto-BlueGoalSide3", Integer.toString(pathState), pathTimer.getElapsedTimeSeconds());
             panelsTelemetry.update(telemetry);
         }
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience1.java
@@ -121,6 +121,7 @@ public class RedAudience1 extends DarienOpModeFSM {
             panelsTelemetry.addData("Heading", follower.getPose().getHeading());
             panelsTelemetry.addData("Alliance Color", "RED");
             telemetry.addData("Alliance Color Saved", "RED");
+            addTraceTelemetry("Auto-RedAudience1", Integer.toString(pathState), pathTimer.getElapsedTimeSeconds());
             displayRpmTelemetry();
             panelsTelemetry.update(telemetry);
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience2.java
@@ -118,6 +118,7 @@ public class RedAudience2 extends DarienOpModeFSM {
             panelsTelemetry.addData("Heading", follower.getPose().getHeading());
             panelsTelemetry.addData("Alliance Color", "RED");
             telemetry.addData("Alliance Color Saved", "RED");
+            addTraceTelemetry("Auto-RedAudience2", Integer.toString(pathState), pathTimer.getElapsedTimeSeconds());
             displayRpmTelemetry();
             panelsTelemetry.update(telemetry);
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience3.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience3.java
@@ -90,6 +90,7 @@ public class RedAudience3 extends DarienOpModeFSM {
             panelsTelemetry.addData("Heading", follower.getPose().getHeading());
             panelsTelemetry.addData("Alliance Color", "RED");
             telemetry.addData("Alliance Color Saved", "RED");
+            addTraceTelemetry("Auto-RedAudience3", Integer.toString(pathState), pathTimer.getElapsedTimeSeconds());
             panelsTelemetry.update(telemetry);
         }
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide1.java
@@ -123,6 +123,7 @@ public class RedGoalSide1 extends DarienOpModeFSM {
             panelsTelemetry.addData("Heading", follower.getPose().getHeading());
             panelsTelemetry.addData("Alliance Color", "RED");
             telemetry.addData("Alliance Color Saved", "RED");
+            addTraceTelemetry("Auto-RedGoalSide1", Integer.toString(pathState), pathTimer.getElapsedTimeSeconds());
             displayRpmTelemetry();
             panelsTelemetry.update(telemetry);
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide2.java
@@ -126,6 +126,7 @@ public class RedGoalSide2 extends DarienOpModeFSM {
             panelsTelemetry.addData("Heading", follower.getPose().getHeading());
             panelsTelemetry.addData("Alliance Color", "RED");
             telemetry.addData("Alliance Color Saved", "RED");
+            addTraceTelemetry("Auto-RedGoalSide2", Integer.toString(pathState), pathTimer.getElapsedTimeSeconds());
             displayRpmTelemetry();
             panelsTelemetry.update(telemetry);
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/DarienOpModeFSM.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/DarienOpModeFSM.java
@@ -393,4 +393,32 @@ public abstract class DarienOpModeFSM extends LinearOpMode {
         telemetry.addData("Shooting Power Mode", shootingPowerMode.toString());
     }
 
+    /**
+     * Adds a shared trace telemetry schema for TeleOp and autonomous loops.
+     */
+    protected void addTraceTelemetry(String phase, String state, double stateTimerSec) {
+        telemetry.addData("TRACE/Phase", phase);
+        telemetry.addData("TRACE/State", state);
+        telemetry.addData("TRACE/RuntimeSec", String.format("%.2f", getRuntime()));
+        telemetry.addData("TRACE/StateTimerSec", String.format("%.2f", stateTimerSec));
+
+        if (follower != null) {
+            telemetry.addData(
+                    "TRACE/Pose",
+                    String.format(
+                            "x=%.1f y=%.1f h=%.1fdeg",
+                            follower.getPose().getX(),
+                            follower.getPose().getY(),
+                            Math.toDegrees(follower.getPose().getHeading())
+                    )
+            );
+        } else {
+            telemetry.addData("TRACE/Pose", "unavailable");
+        }
+
+        telemetry.addData("TRACE/TurretMode", turretFSM != null ? turretFSM.getState() : "unavailable");
+        telemetry.addData("TRACE/ShooterMode", shootingPowerMode);
+        telemetry.addData("TRACE/ShooterStage", shootingFSM != null ? shootingFSM.getStage() : "unavailable");
+    }
+
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/TeleOpFSM.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/TeleOpFSM.java
@@ -472,6 +472,10 @@ public class TeleOpFSM extends DarienOpModeFSM {
                 telemetry.addLine("Move any stick to cancel");
             }
 
+            String traceState = isAutoParking ? "AUTO_PARK" : "DRIVER_CONTROL";
+            double traceStateTimer = isAutoParking ? (getRuntime() - autoParkStartTime) : 0.0;
+            addTraceTelemetry("TeleOp", traceState, traceStateTimer);
+
             telemetry.update();
         } //while opModeIsActive
     } //runOpMode


### PR DESCRIPTION
Introduce a shared trace telemetry helper in `DarienOpModeFSM` and wire it into `TeleOpFSM` plus every autonomous OpMode under `team/autosPedroPathing`.

Changes:
- add `addTraceTelemetry(phase, state, stateTimerSec)` in `DarienOpModeFSM`
- emit trace telemetry in `TeleOpFSM` (`DRIVER_CONTROL` / `AUTO_PARK`)
- emit trace telemetry in all autos:
  - BlueAudience1/2
  - BlueGoalSide1/2/3
  - RedAudience1/2/3
  - RedGoalSide1/2
- add docs: `docs/TRACE_TELEMETRY_SCHEMA.md`
- update docs index: `docs/README.md`

Trace keys added:
`TRACE/Phase`, `TRACE/State`, `TRACE/RuntimeSec`, `TRACE/StateTimerSec`, `TRACE/Pose`, `TRACE/TurretMode`, `TRACE/ShooterMode`, `TRACE/ShooterStage`.

Behavior impact:
- telemetry-only refactor baseline update (no intended runtime behavior changes)

Verification:
- `:TeamCode:assembleDebug` passes

