### PR TITLE
Feature/refactor p1 robot container

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience1.java
@@ -12,10 +12,6 @@ import com.pedropathing.paths.PathChain;
 import com.pedropathing.util.Timer;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 
-import android.content.SharedPreferences;
-
-import org.firstinspires.ftc.robotcore.internal.system.AppUtil;
-
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 
@@ -67,8 +63,7 @@ public class BlueAudience1 extends DarienOpModeFSM {
         turretFSM.center();
 
         // Save alliance color to shared preferences for TeleOp
-        SharedPreferences prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-        prefs.edit().putString("auto_alliance", "BLUE").apply();
+        preferencesService.saveAutoAlliance("BLUE");
 
         telemetry.addLine("Alliance Color: BLUE (Saved to Preferences)");
 
@@ -99,12 +94,11 @@ public class BlueAudience1 extends DarienOpModeFSM {
             turretFSM.setPositionFromOdometry(targetGoalX, targetGoalY, robotX, robotY, robotHeadingRadians);
 
             // Save final odometry position to SharedPreferences for TeleOp
-            prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-            prefs.edit()
-                    .putFloat("auto_final_x", (float) follower.getPose().getX())
-                    .putFloat("auto_final_y", (float) follower.getPose().getY())
-                    .putFloat("auto_final_heading", (float) follower.getPose().getHeading())
-                    .apply();
+            preferencesService.saveAutoFinalPose(
+                    (float) follower.getPose().getX(),
+                    (float) follower.getPose().getY(),
+                    (float) follower.getPose().getHeading()
+            );
 
             telemetry.addData("Saved Odometry", String.format("X=%.1f, Y=%.1f, H=%.1f°",
                                                               follower.getPose().getX(),

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience2.java
@@ -12,10 +12,6 @@ import com.pedropathing.paths.PathChain;
 import com.pedropathing.util.Timer;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 
-import android.content.SharedPreferences;
-
-import org.firstinspires.ftc.robotcore.internal.system.AppUtil;
-
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 
@@ -65,8 +61,7 @@ public class BlueAudience2 extends DarienOpModeFSM {
         turretFSM.center();
 
         // Save alliance color to shared preferences for TeleOp
-        SharedPreferences prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-        prefs.edit().putString("auto_alliance", "BLUE").apply();
+        preferencesService.saveAutoAlliance("BLUE");
 
         telemetry.addLine("Alliance Color: BLUE (Saved to Preferences)");
 
@@ -97,12 +92,11 @@ public class BlueAudience2 extends DarienOpModeFSM {
             turretFSM.setPositionFromOdometry(targetGoalX, targetGoalY, robotX, robotY, robotHeadingRadians);
 
             // Save final odometry position to SharedPreferences for TeleOp
-            prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-            prefs.edit()
-                    .putFloat("auto_final_x", (float) follower.getPose().getX())
-                    .putFloat("auto_final_y", (float) follower.getPose().getY())
-                    .putFloat("auto_final_heading", (float) follower.getPose().getHeading())
-                    .apply();
+            preferencesService.saveAutoFinalPose(
+                    (float) follower.getPose().getX(),
+                    (float) follower.getPose().getY(),
+                    (float) follower.getPose().getHeading()
+            );
 
             telemetry.addData("Saved Odometry", String.format("X=%.1f, Y=%.1f, H=%.1f°",
                                                               follower.getPose().getX(),

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide1.java
@@ -11,10 +11,6 @@ import com.pedropathing.paths.PathChain;
 import com.pedropathing.util.Timer;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 
-import android.content.SharedPreferences;
-
-import org.firstinspires.ftc.robotcore.internal.system.AppUtil;
-
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 
@@ -69,8 +65,7 @@ public class BlueGoalSide1 extends DarienOpModeFSM {
         turretFSM.center();
 
         // Save alliance color to shared preferences for TeleOp
-        SharedPreferences prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-        prefs.edit().putString("auto_alliance", "BLUE").apply();
+        preferencesService.saveAutoAlliance("BLUE");
 
         telemetry.addLine("Alliance Color: BLUE (Saved to Preferences)");
 
@@ -101,12 +96,11 @@ public class BlueGoalSide1 extends DarienOpModeFSM {
             turretFSM.setPositionFromOdometry(targetGoalX, targetGoalY, robotX, robotY, robotHeadingRadians);
 
             // Save final odometry position to SharedPreferences for TeleOp
-            prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-            prefs.edit()
-                    .putFloat("auto_final_x", (float) follower.getPose().getX())
-                    .putFloat("auto_final_y", (float) follower.getPose().getY())
-                    .putFloat("auto_final_heading", (float) follower.getPose().getHeading())
-                    .apply();
+            preferencesService.saveAutoFinalPose(
+                    (float) follower.getPose().getX(),
+                    (float) follower.getPose().getY(),
+                    (float) follower.getPose().getHeading()
+            );
 
             telemetry.addData("Saved Odometry", String.format("X=%.1f, Y=%.1f, H=%.1f°",
                     follower.getPose().getX(),

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide2.java
@@ -12,10 +12,6 @@ import com.pedropathing.paths.PathChain;
 import com.pedropathing.util.Timer;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 
-import android.content.SharedPreferences;
-
-import org.firstinspires.ftc.robotcore.internal.system.AppUtil;
-
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 
@@ -68,8 +64,7 @@ public class BlueGoalSide2 extends DarienOpModeFSM {
         turretFSM.center();
 
         // Save alliance color to shared preferences for TeleOp
-        SharedPreferences prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-        prefs.edit().putString("auto_alliance", "BLUE").apply();
+        preferencesService.saveAutoAlliance("BLUE");
 
         telemetry.addLine("Alliance Color: BLUE (Saved to Preferences)");
 
@@ -100,12 +95,11 @@ public class BlueGoalSide2 extends DarienOpModeFSM {
             turretFSM.setPositionFromOdometry(targetGoalX, targetGoalY, robotX, robotY, robotHeadingRadians);
 
             // Save final odometry position to SharedPreferences for TeleOp
-            prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-            prefs.edit()
-                    .putFloat("auto_final_x", (float) follower.getPose().getX())
-                    .putFloat("auto_final_y", (float) follower.getPose().getY())
-                    .putFloat("auto_final_heading", (float) follower.getPose().getHeading())
-                    .apply();
+            preferencesService.saveAutoFinalPose(
+                    (float) follower.getPose().getX(),
+                    (float) follower.getPose().getY(),
+                    (float) follower.getPose().getHeading()
+            );
 
             telemetry.addData("Saved Odometry", String.format("X=%.1f, Y=%.1f, H=%.1f°",
                     follower.getPose().getX(),

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide3.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide3.java
@@ -12,10 +12,6 @@ import com.pedropathing.util.Timer;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 
-import android.content.SharedPreferences;
-
-import org.firstinspires.ftc.robotcore.internal.system.AppUtil;
-
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 
@@ -64,8 +60,7 @@ public class BlueGoalSide3 extends DarienOpModeFSM {
         turretFSM.center();
 
         // Save alliance color to shared preferences for TeleOp
-        SharedPreferences prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-        prefs.edit().putString("auto_alliance", "BLUE").apply();
+        preferencesService.saveAutoAlliance("BLUE");
 
         telemetry.addLine("Alliance Color: BLUE (Saved to Preferences)");
 
@@ -90,12 +85,11 @@ public class BlueGoalSide3 extends DarienOpModeFSM {
             turretFSM.setPositionFromOdometry(targetGoalX, targetGoalY, robotX, robotY, robotHeadingRadians);
 
             // Save final odometry position to SharedPreferences for TeleOp
-            prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-            prefs.edit()
-                    .putFloat("auto_final_x", (float) follower.getPose().getX())
-                    .putFloat("auto_final_y", (float) follower.getPose().getY())
-                    .putFloat("auto_final_heading", (float) follower.getPose().getHeading())
-                    .apply();
+            preferencesService.saveAutoFinalPose(
+                    (float) follower.getPose().getX(),
+                    (float) follower.getPose().getY(),
+                    (float) follower.getPose().getHeading()
+            );
 
             telemetry.addData("Saved Odometry", String.format("X=%.1f, Y=%.1f, H=%.1f°",
                     follower.getPose().getX(),

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience1.java
@@ -12,10 +12,6 @@ import com.pedropathing.paths.PathChain;
 import com.pedropathing.util.Timer;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 
-import android.content.SharedPreferences;
-
-import org.firstinspires.ftc.robotcore.internal.system.AppUtil;
-
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 
@@ -67,8 +63,7 @@ public class RedAudience1 extends DarienOpModeFSM {
         turretFSM.center();
 
         // Save alliance color to shared preferences for TeleOp
-        SharedPreferences prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-        prefs.edit().putString("auto_alliance", "RED").apply();
+        preferencesService.saveAutoAlliance("RED");
 
         telemetry.addLine("Alliance Color: RED (Saved to Preferences)");
 
@@ -99,12 +94,11 @@ public class RedAudience1 extends DarienOpModeFSM {
             turretFSM.setPositionFromOdometry(targetGoalX, targetGoalY, robotX, robotY, robotHeadingRadians);
 
             // Save final odometry position to SharedPreferences for TeleOp
-            prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-            prefs.edit()
-                    .putFloat("auto_final_x", (float) follower.getPose().getX())
-                    .putFloat("auto_final_y", (float) follower.getPose().getY())
-                    .putFloat("auto_final_heading", (float) follower.getPose().getHeading())
-                    .apply();
+            preferencesService.saveAutoFinalPose(
+                    (float) follower.getPose().getX(),
+                    (float) follower.getPose().getY(),
+                    (float) follower.getPose().getHeading()
+            );
 
             telemetry.addData("Saved Odometry", String.format("X=%.1f, Y=%.1f, H=%.1f°",
                                                               follower.getPose().getX(),

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience2.java
@@ -11,10 +11,6 @@ import com.pedropathing.geometry.Pose;
 import com.pedropathing.paths.PathChain;
 import com.pedropathing.util.Timer;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
-
-import android.content.SharedPreferences;
-
-import org.firstinspires.ftc.robotcore.internal.system.AppUtil;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 
@@ -64,8 +60,7 @@ public class RedAudience2 extends DarienOpModeFSM {
         turretFSM.center();
 
         // Save alliance color to shared preferences for TeleOp
-        SharedPreferences prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-        prefs.edit().putString("auto_alliance", "RED").apply();
+        preferencesService.saveAutoAlliance("RED");
 
         telemetry.addLine("Alliance Color: RED (Saved to Preferences)");
 
@@ -96,12 +91,11 @@ public class RedAudience2 extends DarienOpModeFSM {
             turretFSM.setPositionFromOdometry(targetGoalX, targetGoalY, robotX, robotY, robotHeadingRadians);
 
             // Save final odometry position to SharedPreferences for TeleOp
-            prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-            prefs.edit()
-                    .putFloat("auto_final_x", (float) follower.getPose().getX())
-                    .putFloat("auto_final_y", (float) follower.getPose().getY())
-                    .putFloat("auto_final_heading", (float) follower.getPose().getHeading())
-                    .apply();
+            preferencesService.saveAutoFinalPose(
+                    (float) follower.getPose().getX(),
+                    (float) follower.getPose().getY(),
+                    (float) follower.getPose().getHeading()
+            );
 
             telemetry.addData("Saved Odometry", String.format("X=%.1f, Y=%.1f, H=%.1f°",
                                                               follower.getPose().getX(),

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience3.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience3.java
@@ -12,10 +12,6 @@ import com.pedropathing.paths.PathChain;
 import com.pedropathing.util.Timer;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 import com.qualcomm.robotcore.eventloop.opmode.Disabled;
-
-import android.content.SharedPreferences;
-
-import org.firstinspires.ftc.robotcore.internal.system.AppUtil;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 
 
@@ -60,8 +56,7 @@ public class RedAudience3 extends DarienOpModeFSM {
         panelsTelemetry.update(telemetry);
 
         // Save alliance color to shared preferences for TeleOp
-        SharedPreferences prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-        prefs.edit().putString("auto_alliance", "RED").apply();
+        preferencesService.saveAutoAlliance("RED");
 
         telemetry.addLine("Alliance Color: RED (Saved to Preferences)");
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide1.java
@@ -11,10 +11,6 @@ import com.pedropathing.paths.PathChain;
 import com.pedropathing.util.Timer;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 
-import android.content.SharedPreferences;
-
-import org.firstinspires.ftc.robotcore.internal.system.AppUtil;
-
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 
@@ -69,8 +65,7 @@ public class RedGoalSide1 extends DarienOpModeFSM {
         turretFSM.center();
 
         // Save alliance color to shared preferences for TeleOp
-        SharedPreferences prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-        prefs.edit().putString("auto_alliance", "RED").apply();
+        preferencesService.saveAutoAlliance("RED");
 
         telemetry.addLine("Alliance Color: RED (Saved to Preferences)");
 
@@ -101,12 +96,11 @@ public class RedGoalSide1 extends DarienOpModeFSM {
             turretFSM.setPositionFromOdometry(targetGoalX, targetGoalY, robotX, robotY, robotHeadingRadians);
 
             // Save final odometry position to SharedPreferences for TeleOp
-            prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-            prefs.edit()
-                    .putFloat("auto_final_x", (float) follower.getPose().getX())
-                    .putFloat("auto_final_y", (float) follower.getPose().getY())
-                    .putFloat("auto_final_heading", (float) follower.getPose().getHeading())
-                    .apply();
+            preferencesService.saveAutoFinalPose(
+                    (float) follower.getPose().getX(),
+                    (float) follower.getPose().getY(),
+                    (float) follower.getPose().getHeading()
+            );
 
             telemetry.addData("Saved Odometry", String.format("X=%.1f, Y=%.1f, H=%.1f°",
                                                               follower.getPose().getX(),

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide2.java
@@ -12,10 +12,6 @@ import com.pedropathing.paths.PathChain;
 import com.pedropathing.util.Timer;
 import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
 
-import android.content.SharedPreferences;
-
-import org.firstinspires.ftc.robotcore.internal.system.AppUtil;
-
 
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
@@ -70,8 +66,7 @@ public class RedGoalSide2 extends DarienOpModeFSM {
         turretFSM.center();
 
         // Save alliance color to shared preferences for TeleOp
-        SharedPreferences prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-        prefs.edit().putString("auto_alliance", "RED").apply();
+        preferencesService.saveAutoAlliance("RED");
 
         telemetry.addLine("Alliance Color: RED (Saved to Preferences)");
 
@@ -103,12 +98,11 @@ public class RedGoalSide2 extends DarienOpModeFSM {
             turretFSM.setPositionFromOdometry(targetGoalX, targetGoalY, robotX, robotY, robotHeadingRadians);
 
             // Save final odometry position to SharedPreferences for TeleOp
-            prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-            prefs.edit()
-                    .putFloat("auto_final_x", (float) follower.getPose().getX())
-                    .putFloat("auto_final_y", (float) follower.getPose().getY())
-                    .putFloat("auto_final_heading", (float) follower.getPose().getHeading())
-                    .apply();
+            preferencesService.saveAutoFinalPose(
+                    (float) follower.getPose().getX(),
+                    (float) follower.getPose().getY(),
+                    (float) follower.getPose().getHeading()
+            );
 
             telemetry.addData("Saved Odometry", String.format("X=%.1f, Y=%.1f, H=%.1f°",
                                                               follower.getPose().getX(),

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/core/RobotContainer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/core/RobotContainer.java
@@ -1,0 +1,137 @@
+package org.firstinspires.ftc.teamcode.team.core;
+
+import com.pedropathing.follower.Follower;
+
+import org.firstinspires.ftc.teamcode.team.MotorHelper;
+import org.firstinspires.ftc.teamcode.team.fsm.AprilTagDetectionFSM;
+import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
+import org.firstinspires.ftc.teamcode.team.fsm.GateFSM;
+import org.firstinspires.ftc.teamcode.team.fsm.IntakeFSM;
+import org.firstinspires.ftc.teamcode.team.fsm.ShootArtifactFSM;
+import org.firstinspires.ftc.teamcode.team.fsm.ShootPatternFSM;
+import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
+import org.firstinspires.ftc.teamcode.team.fsm.ShotgunFSM;
+import org.firstinspires.ftc.teamcode.team.fsm.TurretFSM;
+import org.firstinspires.ftc.teamcode.team.hardware.RobotHardware;
+import org.firstinspires.ftc.teamcode.team.services.AprilTagVisionService;
+import org.firstinspires.ftc.teamcode.team.services.PreferencesService;
+import org.firstinspires.ftc.teamcode.team.services.RobotServices;
+import org.firstinspires.ftc.vision.VisionPortal;
+import org.firstinspires.ftc.vision.apriltag.AprilTagProcessor;
+
+/**
+ * Composes robot hardware, services, and subsystem FSM instances for an OpMode.
+ */
+public class RobotContainer {
+
+    private final DarienOpModeFSM opMode;
+    private final RobotHardware hardware;
+    private final RobotServices services;
+
+    private MotorHelper motorHelper;
+
+    private AprilTagDetectionFSM tagFSM;
+    private ShootPatternFSM shootPatternFSM;
+    private ShootArtifactFSM shootArtifactFSM;
+    private ShotgunFSM shotgunFSM;
+    private TurretFSM turretFSM;
+    private GateFSM gateFSM;
+    private IntakeFSM intakeFSM;
+    private ShootingFSM shootingFSM;
+
+    public RobotContainer(DarienOpModeFSM opMode) {
+        this.opMode = opMode;
+        this.hardware = new RobotHardware();
+        this.services = new RobotServices(opMode);
+    }
+
+    public void initialize() {
+        hardware.initialize(opMode.hardwareMap);
+        services.initialize();
+
+        motorHelper = new MotorHelper(opMode.telemetry, DarienOpModeFSM.TICKS_PER_ROTATION);
+
+        tagFSM = new AprilTagDetectionFSM(services.getVisionService().getAprilTagProcessor(), DarienOpModeFSM.TIMEOUT_APRILTAG_DETECTION);
+        shootArtifactFSM = new ShootArtifactFSM(opMode);
+        shootPatternFSM = new ShootPatternFSM(opMode);
+        shotgunFSM = new ShotgunFSM(
+                DarienOpModeFSM.SHOT_GUN_POWER_UP,
+                DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR,
+                hardware.ejectionMotor,
+                opMode,
+                motorHelper
+        );
+
+        turretFSM = new TurretFSM(opMode.hardwareMap);
+        turretFSM.init();
+
+        gateFSM = new GateFSM(opMode.hardwareMap);
+        gateFSM.init();
+
+        intakeFSM = new IntakeFSM(opMode.hardwareMap, gateFSM);
+        intakeFSM.init();
+
+        shootingFSM = new ShootingFSM(gateFSM, shotgunFSM, intakeFSM, opMode);
+    }
+
+    public RobotHardware getHardware() {
+        return hardware;
+    }
+
+    public Follower getFollower() {
+        return services.getFollower();
+    }
+
+    public MotorHelper getMotorHelper() {
+        return motorHelper;
+    }
+
+    public AprilTagProcessor getAprilTag() {
+        return services.getVisionService().getAprilTagProcessor();
+    }
+
+    public VisionPortal getVisionPortal() {
+        return services.getVisionService().getVisionPortal();
+    }
+
+    public AprilTagVisionService getVisionService() {
+        return services.getVisionService();
+    }
+
+    public PreferencesService getPreferencesService() {
+        return services.getPreferencesService();
+    }
+
+    public AprilTagDetectionFSM getTagFSM() {
+        return tagFSM;
+    }
+
+    public ShootPatternFSM getShootPatternFSM() {
+        return shootPatternFSM;
+    }
+
+    public ShootArtifactFSM getShootArtifactFSM() {
+        return shootArtifactFSM;
+    }
+
+    public ShotgunFSM getShotgunFSM() {
+        return shotgunFSM;
+    }
+
+    public TurretFSM getTurretFSM() {
+        return turretFSM;
+    }
+
+    public GateFSM getGateFSM() {
+        return gateFSM;
+    }
+
+    public IntakeFSM getIntakeFSM() {
+        return intakeFSM;
+    }
+
+    public ShootingFSM getShootingFSM() {
+        return shootingFSM;
+    }
+}
+

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/DarienOpModeFSM.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/DarienOpModeFSM.java
@@ -10,16 +10,15 @@ import com.qualcomm.robotcore.hardware.DcMotorEx;
 
 import com.pedropathing.follower.Follower;
 
-import org.firstinspires.ftc.robotcore.external.hardware.camera.controls.ExposureControl;
-import org.firstinspires.ftc.robotcore.external.hardware.camera.controls.GainControl;
-import org.firstinspires.ftc.teamcode.pedroPathing.Constants;
+import org.firstinspires.ftc.teamcode.team.core.RobotContainer;
 import org.firstinspires.ftc.teamcode.team.MotorHelper;
+import org.firstinspires.ftc.teamcode.team.services.AprilTagVisionService;
+import org.firstinspires.ftc.teamcode.team.services.PreferencesService;
 import org.firstinspires.ftc.vision.apriltag.AprilTagProcessor;
 import org.firstinspires.ftc.vision.VisionPortal;
 import org.firstinspires.ftc.vision.apriltag.AprilTagDetection;
 
 import java.util.ArrayList;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Base OpMode for Pedro pathing and state machine logic.
@@ -141,6 +140,9 @@ public abstract class DarienOpModeFSM extends LinearOpMode {
     public static double CAMERA_FALLBACK_TIMEOUT_MS = 500; // Auto-switch to odometry after this timeout
 
     public int targetGoalId = 0;
+    protected RobotContainer robotContainer;
+    protected AprilTagVisionService visionService;
+    protected PreferencesService preferencesService;
 
     public enum ShotgunPowerLevel {
         OFF,
@@ -166,34 +168,31 @@ public abstract class DarienOpModeFSM extends LinearOpMode {
         tp = new TelemetryPacket();
         dash = FtcDashboard.getInstance();
 
-        // INITIALIZE MOTORS
-        ejectionMotor = hardwareMap.get(DcMotorEx.class, "ejectionMotor");
-        ejectionMotor.setZeroPowerBehavior(DcMotorEx.ZeroPowerBehavior.FLOAT);
-        ejectionMotor.setMode(DcMotorEx.RunMode.RUN_USING_ENCODER);
-        ejectionMotor.setDirection(DcMotorEx.Direction.REVERSE); // Reverse because it is geared
+        // Delegate robot hardware/services/subsystems initialization to container.
+        if (robotContainer == null) {
+            robotContainer = new RobotContainer(this);
+        }
+        robotContainer.initialize();
+        visionService = robotContainer.getVisionService();
+        preferencesService = robotContainer.getPreferencesService();
 
-        initAprilTag();
-
-        MotorHelper = new MotorHelper(telemetry, TICKS_PER_ROTATION);
+        ejectionMotor = robotContainer.getHardware().ejectionMotor;
+        aprilTag = robotContainer.getAprilTag();
+        visionPortal = robotContainer.getVisionPortal();
+        MotorHelper = robotContainer.getMotorHelper();
+        tagFSM = robotContainer.getTagFSM();
+        shootArtifactFSM = robotContainer.getShootArtifactFSM();
+        shootPatternFSM = robotContainer.getShootPatternFSM();
+        shotgunFSM = robotContainer.getShotgunFSM();
+        turretFSM = robotContainer.getTurretFSM();
+        gateFSM = robotContainer.getGateFSM();
+        intakeFSM = robotContainer.getIntakeFSM();
+        shootingFSM = robotContainer.getShootingFSM();
+        follower = robotContainer.getFollower();
 
         // Set default shooting power mode: ODOMETRY for Autos, MANUAL for TeleOp
         shootingPowerMode = isAutonomousMode() ? ShootingPowerModes.ODOMETRY : ShootingPowerModes.MANUAL;
 
-        // INSTANTIATE THE STATE MACHINES
-        tagFSM = new AprilTagDetectionFSM(aprilTag, TIMEOUT_APRILTAG_DETECTION);
-        shootArtifactFSM = new ShootArtifactFSM(this);
-        shootPatternFSM = new ShootPatternFSM(this);
-        shotgunFSM = new ShotgunFSM(SHOT_GUN_POWER_UP, SHOT_GUN_POWER_UP_FAR, ejectionMotor, this, MotorHelper);
-        turretFSM = new TurretFSM(this.hardwareMap);
-        turretFSM.init();
-        gateFSM = new GateFSM(this.hardwareMap);
-        gateFSM.init();
-        intakeFSM = new IntakeFSM(this.hardwareMap, this.gateFSM);
-        intakeFSM.init();
-        shootingFSM = new ShootingFSM(this.gateFSM, this.shotgunFSM, this.intakeFSM, this);
-
-        // Create Pedro Pathing follower — available to all subclasses (Teleop + Autos)
-        follower = Constants.createFollower(hardwareMap);
 
         telemetry.addLine("FTC 19168 Robot Initialization Done!");
         telemetry.update();
@@ -224,118 +223,9 @@ public abstract class DarienOpModeFSM extends LinearOpMode {
         return motor;
     }
 
-    /**
-     * Initialize the AprilTag processor.
-     */
-    private void initAprilTag() {
-
-        // Create the AprilTag processor the easy way.
-        aprilTag = AprilTagProcessor.easyCreateWithDefaults();
-
-
-        // Set manual exposure and gain to reduce motion blur and improve detection at distance
-        // This is especially important for detecting AprilTags from far positions
-        //setManualExposure(APRILTAG_EXPOSURE_MS, APRILTAG_GAIN);
-    }
-
-    /**
-     * Manually set the camera gain and exposure for AprilTag detection.
-     * Low exposure (5-6ms) with high gain reduces motion blur.
-     * Can only be called AFTER calling initAprilTag().
-     *
-     * @param exposureMS Camera exposure time in milliseconds
-     * @param gain       Camera gain value (typically 0-255)
-     * @return true if controls are set successfully
-     */
-    private boolean setManualExposure(int exposureMS, int gain) {
-        // Ensure Vision Portal has been setup
-        if (visionPortal == null) {
-            return false;
-        }
-
-        // Wait for the camera to be open
-        if (visionPortal.getCameraState() != VisionPortal.CameraState.STREAMING) {
-            telemetry.addData("Camera", "Waiting for stream...");
-            telemetry.update();
-            while (!isStopRequested() && (visionPortal.getCameraState() != VisionPortal.CameraState.STREAMING)) {
-                sleep(20);
-            }
-            telemetry.addData("Camera", "Ready");
-            telemetry.update();
-        }
-
-        // Set camera controls unless we are stopping
-        if (!isStopRequested()) {
-            try {
-                // Set exposure - must be in Manual Mode for these values to take effect
-                ExposureControl exposureControl = visionPortal.getCameraControl(ExposureControl.class);
-                if (exposureControl.getMode() != ExposureControl.Mode.Manual) {
-                    exposureControl.setMode(ExposureControl.Mode.Manual);
-                    sleep(50);
-                }
-                exposureControl.setExposure(exposureMS, TimeUnit.MILLISECONDS);
-                sleep(20);
-
-                // Set Gain
-                GainControl gainControl = visionPortal.getCameraControl(GainControl.class);
-                gainControl.setGain(gain);
-                sleep(20);
-
-                telemetry.addData("Camera Exposure", exposureMS + "ms");
-                telemetry.addData("Camera Gain", gain);
-                telemetry.update();
-                return true;
-            } catch (Exception e) {
-                telemetry.addData("Camera Control Error", e.getMessage());
-                telemetry.update();
-                return false;
-            }
-        } else {
-            return false;
-        }
-    }
-
-    /**
-     * Read this camera's minimum and maximum Exposure and Gain settings.
-     * Useful for tuning and debugging.
-     * Can only be called AFTER calling initAprilTag().
-     *
-     * @return int array: [minExposure, maxExposure, minGain, maxGain]
-     */
+    /** Read this camera's minimum and maximum Exposure and Gain settings. */
     public int[] getCameraSettings() {
-        // Ensure Vision Portal has been setup
-        if (visionPortal == null) {
-            return new int[]{0, 0, 0, 0};
-        }
-
-        // Wait for the camera to be open
-        if (visionPortal.getCameraState() != VisionPortal.CameraState.STREAMING) {
-            telemetry.addData("Camera", "Waiting for stream...");
-            telemetry.update();
-            while (!isStopRequested() && (visionPortal.getCameraState() != VisionPortal.CameraState.STREAMING)) {
-                sleep(20);
-            }
-        }
-
-        // Get camera control values unless we are stopping
-        if (!isStopRequested()) {
-            try {
-                ExposureControl exposureControl = visionPortal.getCameraControl(ExposureControl.class);
-                int minExposure = (int) exposureControl.getMinExposure(TimeUnit.MILLISECONDS) + 1;
-                int maxExposure = (int) exposureControl.getMaxExposure(TimeUnit.MILLISECONDS);
-
-                GainControl gainControl = visionPortal.getCameraControl(GainControl.class);
-                int minGain = gainControl.getMinGain();
-                int maxGain = gainControl.getMaxGain();
-
-                return new int[]{minExposure, maxExposure, minGain, maxGain};
-            } catch (Exception e) {
-                telemetry.addData("Camera Settings Error", e.getMessage());
-                telemetry.update();
-                return new int[]{0, 0, 0, 0};
-            }
-        }
-        return new int[]{0, 0, 0, 0};
+        return (visionService != null) ? visionService.getCameraSettings() : new int[]{0, 0, 0, 0};
     }
 
     /**

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/TeleOpFSM.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/TeleOpFSM.java
@@ -20,9 +20,6 @@ import org.firstinspires.ftc.vision.apriltag.AprilTagDetection;
 import com.bylazar.configurables.annotations.Configurable;
 
 import android.annotation.SuppressLint;
-import android.content.SharedPreferences;
-
-import org.firstinspires.ftc.robotcore.internal.system.AppUtil;
 
 @TeleOp(name = "TeleopFSM", group = "DriverControl")
 @Config
@@ -81,8 +78,7 @@ public class TeleOpFSM extends DarienOpModeFSM {
         tp = new TelemetryPacket();
         dash = FtcDashboard.getInstance();
 
-        SharedPreferences prefs = AppUtil.getInstance().getActivity().getSharedPreferences("ftc_prefs", android.content.Context.MODE_PRIVATE);
-        autoAlliance = prefs.getString("auto_alliance", "UNKNOWN");
+        autoAlliance = preferencesService.getAutoAlliance("UNKNOWN");
 
         // Set align color based on saved color from auto
         if ("BLUE".equals(autoAlliance)) {
@@ -94,11 +90,11 @@ public class TeleOpFSM extends DarienOpModeFSM {
         }
 
         // Load saved odometry position from auto (if available)
-        boolean hasAutoPosition = prefs.contains("auto_final_x");
+        boolean hasAutoPosition = preferencesService.hasAutoFinalPose();
         if (hasAutoPosition) {
-            double autoX = prefs.getFloat("auto_final_x", 0f);
-            double autoY = prefs.getFloat("auto_final_y", 0f);
-            double autoHeadingRad = prefs.getFloat("auto_final_heading", 0f);
+            double autoX = preferencesService.getAutoFinalX(0f);
+            double autoY = preferencesService.getAutoFinalY(0f);
+            double autoHeadingRad = preferencesService.getAutoFinalHeading(0f);
 
             // Set odometry position from auto
             odo.setPosition(new Pose2D(

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/hardware/RobotHardware.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/hardware/RobotHardware.java
@@ -1,0 +1,21 @@
+package org.firstinspires.ftc.teamcode.team.hardware;
+
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.DcMotorEx;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+
+/**
+ * Central hardware mapping for robot devices used by shared FSM infrastructure.
+ */
+public class RobotHardware {
+
+    public DcMotorEx ejectionMotor;
+
+    public void initialize(HardwareMap hardwareMap) {
+        ejectionMotor = hardwareMap.get(DcMotorEx.class, "ejectionMotor");
+        ejectionMotor.setZeroPowerBehavior(DcMotorEx.ZeroPowerBehavior.FLOAT);
+        ejectionMotor.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        ejectionMotor.setDirection(DcMotorEx.Direction.REVERSE); // Reverse because it is geared.
+    }
+}
+

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/services/AprilTagVisionService.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/services/AprilTagVisionService.java
@@ -1,0 +1,114 @@
+package org.firstinspires.ftc.teamcode.team.services;
+
+import org.firstinspires.ftc.robotcore.external.hardware.camera.controls.ExposureControl;
+import org.firstinspires.ftc.robotcore.external.hardware.camera.controls.GainControl;
+import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
+import org.firstinspires.ftc.vision.VisionPortal;
+import org.firstinspires.ftc.vision.apriltag.AprilTagProcessor;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Owns AprilTag processor and camera control helpers for an OpMode lifecycle.
+ */
+public class AprilTagVisionService {
+
+    private final DarienOpModeFSM opMode;
+    private AprilTagProcessor aprilTagProcessor;
+    private VisionPortal visionPortal;
+
+    public AprilTagVisionService(DarienOpModeFSM opMode) {
+        this.opMode = opMode;
+    }
+
+    public void initializeAprilTagProcessor() {
+        aprilTagProcessor = AprilTagProcessor.easyCreateWithDefaults();
+        visionPortal = null;
+    }
+
+    public AprilTagProcessor getAprilTagProcessor() {
+        return aprilTagProcessor;
+    }
+
+    public VisionPortal getVisionPortal() {
+        return visionPortal;
+    }
+
+    public boolean setManualExposure(int exposureMS, int gain) {
+        if (visionPortal == null) {
+            return false;
+        }
+
+        if (visionPortal.getCameraState() != VisionPortal.CameraState.STREAMING) {
+            opMode.telemetry.addData("Camera", "Waiting for stream...");
+            opMode.telemetry.update();
+            while (!opMode.isStopRequested() && (visionPortal.getCameraState() != VisionPortal.CameraState.STREAMING)) {
+                opMode.sleep(20);
+            }
+            opMode.telemetry.addData("Camera", "Ready");
+            opMode.telemetry.update();
+        }
+
+        if (!opMode.isStopRequested()) {
+            try {
+                ExposureControl exposureControl = visionPortal.getCameraControl(ExposureControl.class);
+                if (exposureControl.getMode() != ExposureControl.Mode.Manual) {
+                    exposureControl.setMode(ExposureControl.Mode.Manual);
+                    opMode.sleep(50);
+                }
+                exposureControl.setExposure(exposureMS, TimeUnit.MILLISECONDS);
+                opMode.sleep(20);
+
+                GainControl gainControl = visionPortal.getCameraControl(GainControl.class);
+                gainControl.setGain(gain);
+                opMode.sleep(20);
+
+                opMode.telemetry.addData("Camera Exposure", exposureMS + "ms");
+                opMode.telemetry.addData("Camera Gain", gain);
+                opMode.telemetry.update();
+                return true;
+            } catch (Exception e) {
+                opMode.telemetry.addData("Camera Control Error", e.getMessage());
+                opMode.telemetry.update();
+                return false;
+            }
+        }
+
+        return false;
+    }
+
+    public int[] getCameraSettings() {
+        if (visionPortal == null) {
+            return new int[]{0, 0, 0, 0};
+        }
+
+        if (visionPortal.getCameraState() != VisionPortal.CameraState.STREAMING) {
+            opMode.telemetry.addData("Camera", "Waiting for stream...");
+            opMode.telemetry.update();
+            while (!opMode.isStopRequested() && (visionPortal.getCameraState() != VisionPortal.CameraState.STREAMING)) {
+                opMode.sleep(20);
+            }
+        }
+
+        if (!opMode.isStopRequested()) {
+            try {
+                ExposureControl exposureControl = visionPortal.getCameraControl(ExposureControl.class);
+                int minExposure = (int) exposureControl.getMinExposure(TimeUnit.MILLISECONDS) + 1;
+                int maxExposure = (int) exposureControl.getMaxExposure(TimeUnit.MILLISECONDS);
+
+                GainControl gainControl = visionPortal.getCameraControl(GainControl.class);
+                int minGain = gainControl.getMinGain();
+                int maxGain = gainControl.getMaxGain();
+
+                return new int[]{minExposure, maxExposure, minGain, maxGain};
+            } catch (Exception e) {
+                opMode.telemetry.addData("Camera Settings Error", e.getMessage());
+                opMode.telemetry.update();
+                return new int[]{0, 0, 0, 0};
+            }
+        }
+
+        return new int[]{0, 0, 0, 0};
+    }
+}
+

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/services/PreferencesService.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/services/PreferencesService.java
@@ -1,0 +1,58 @@
+package org.firstinspires.ftc.teamcode.team.services;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import java.util.Objects;
+
+/**
+ * Wrapper around SharedPreferences keys used for Auto -> TeleOp handoff.
+ */
+public class PreferencesService {
+
+    private static final String PREFS_NAME = "ftc_prefs";
+    private static final String KEY_AUTO_ALLIANCE = "auto_alliance";
+    private static final String KEY_AUTO_FINAL_X = "auto_final_x";
+    private static final String KEY_AUTO_FINAL_Y = "auto_final_y";
+    private static final String KEY_AUTO_FINAL_HEADING = "auto_final_heading";
+
+    private final SharedPreferences prefs;
+
+    public PreferencesService(Context context) {
+        Context safeContext = Objects.requireNonNull(context, "Context must not be null");
+        prefs = safeContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
+    }
+
+    public void saveAutoAlliance(String alliance) {
+        prefs.edit().putString(KEY_AUTO_ALLIANCE, alliance).apply();
+    }
+
+    public String getAutoAlliance(String defaultValue) {
+        return prefs.getString(KEY_AUTO_ALLIANCE, defaultValue);
+    }
+
+    public void saveAutoFinalPose(float x, float y, float headingRad) {
+        prefs.edit()
+                .putFloat(KEY_AUTO_FINAL_X, x)
+                .putFloat(KEY_AUTO_FINAL_Y, y)
+                .putFloat(KEY_AUTO_FINAL_HEADING, headingRad)
+                .apply();
+    }
+
+    public boolean hasAutoFinalPose() {
+        return prefs.contains(KEY_AUTO_FINAL_X);
+    }
+
+    public float getAutoFinalX(float defaultValue) {
+        return prefs.getFloat(KEY_AUTO_FINAL_X, defaultValue);
+    }
+
+    public float getAutoFinalY(float defaultValue) {
+        return prefs.getFloat(KEY_AUTO_FINAL_Y, defaultValue);
+    }
+
+    public float getAutoFinalHeading(float defaultValue) {
+        return prefs.getFloat(KEY_AUTO_FINAL_HEADING, defaultValue);
+    }
+}
+

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/services/RobotServices.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/services/RobotServices.java
@@ -1,0 +1,42 @@
+package org.firstinspires.ftc.teamcode.team.services;
+
+import com.pedropathing.follower.Follower;
+
+import org.firstinspires.ftc.teamcode.pedroPathing.Constants;
+import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
+
+/**
+ * Groups non-hardware robot services used by OpModes and subsystem containers.
+ */
+public class RobotServices {
+
+    private final DarienOpModeFSM opMode;
+    private final AprilTagVisionService visionService;
+    private PreferencesService preferencesService;
+
+    private Follower follower;
+
+    public RobotServices(DarienOpModeFSM opMode) {
+        this.opMode = opMode;
+        this.visionService = new AprilTagVisionService(opMode);
+    }
+
+    public void initialize() {
+        visionService.initializeAprilTagProcessor();
+        preferencesService = new PreferencesService(opMode.hardwareMap.appContext);
+        follower = Constants.createFollower(opMode.hardwareMap);
+    }
+
+    public Follower getFollower() {
+        return follower;
+    }
+
+    public AprilTagVisionService getVisionService() {
+        return visionService;
+    }
+
+    public PreferencesService getPreferencesService() {
+        return preferencesService;
+    }
+}
+


### PR DESCRIPTION
## P1 - Robot container skeleton

Implements Phase 1 from `refactoring-plan-2026-05.md`:
- Introduce `RobotHardware` + `RobotContainer` skeleton
- Move shared init wiring out of `DarienOpModeFSM` into container/services
- Keep runtime behavior unchanged

## What changed

### New files
- `TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/hardware/RobotHardware.java`
- `TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/core/RobotContainer.java`
- `TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/services/RobotServices.java`
- `TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/services/AprilTagVisionService.java`
- `TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/services/PreferencesService.java`

### Refactors
- `DarienOpModeFSM` now delegates init responsibilities to `RobotContainer`.
- `RobotContainer` composes hardware + services + FSM instances and returns references.
- `TeleOpFSM` and all autos under `team/autosPedroPathing/` now use `PreferencesService` for `ftc_prefs` handoff data.

## No-change intent

This PR is architectural only:
- no driver-facing OpMode names changed
- no planned behavior changes to TeleOp or autos
- existing public field contracts in `DarienOpModeFSM` preserved for compatibility

## Required PR checklist (phase)

- [x] Scope is limited to one refactor phase (P1)
- [x] No unintended edits outside `TeamCode/`
- [x] Driver-facing OpMode names still exist
- [x] Build passes locally: `:TeamCode:assembleDebug`
- [x] TeleOp smoke test on robot passes:
  - [x] Drive
  - [x] Intake
  - [x] Shooter
  - [x] Turret mode switching
- [x] Auto smoke test on robot passes:
  - [x] `RedGoalSide1`
  - [x] `RedGoalSide2`
- [x] Auto -> TeleOp handoff via `ftc_prefs` is verified
- [x] PR notes include rollback plan and expected no-change behavior

## Exit criteria (P1)

- [x] `DarienOpModeFSM` is thinner and delegates init responsibility
- [x] No startup regressions
- [x] TeleOp + Red autos smoke tests pass with expected behavior

## Rollback plan

Revert this PR commit(s) to restore pre-container init flow in `DarienOpModeFSM`.
No schema or external interface migrations are required for rollback.

## Validation performed

```powershell
./gradlew :TeamCode:assembleDebug