### PR TITLE
fix(p3): harden AprilTag camera fallback for teleop init

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/services/AprilTagService.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/services/AprilTagService.java
@@ -121,6 +121,22 @@ public class AprilTagService {
             return lastSnapshot;
         }
 
+        if (aprilTagProcessor == null) {
+            double elapsedSec = currentTimeSec - startTimeSec;
+            if (elapsedSec >= timeoutSeconds) {
+                lastSnapshot = new Snapshot(
+                        Status.COMPLETE,
+                        startTimeSec,
+                        currentTimeSec,
+                        elapsedSec,
+                        timeoutSeconds,
+                        Collections.<AprilTagDetection>emptyList()
+                );
+                reading = false;
+            }
+            return lastSnapshot;
+        }
+
         List<AprilTagDetection> immutableDetections = copyDetections(aprilTagProcessor.getDetections());
         double elapsedSec = currentTimeSec - startTimeSec;
         boolean done = !immutableDetections.isEmpty() || elapsedSec >= timeoutSeconds;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/services/AprilTagVisionService.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/services/AprilTagVisionService.java
@@ -51,18 +51,18 @@ public class AprilTagVisionService {
     public void initialize() {
         try {
             aprilTagProcessor = new AprilTagProcessor.Builder().build();
+            health = CameraHealth.PORTAL_BUILT;
+            healthDetail = "AprilTag processor built";
+
             visionPortal = new VisionPortal.Builder()
                     .setCamera(opMode.hardwareMap.get(WebcamName.class, "Webcam 1"))
                     .addProcessor(aprilTagProcessor)
                     .build();
-            health = CameraHealth.PORTAL_BUILT;
             healthDetail = "VisionPortal built";
         } catch (Exception e) {
-            health = CameraHealth.BUILD_FAILED;
-            healthDetail = "Build failed: " + e.getMessage();
-            aprilTagProcessor = null;
+            health = (aprilTagProcessor != null) ? CameraHealth.PORTAL_BUILT : CameraHealth.BUILD_FAILED;
+            healthDetail = "Camera unavailable; running odometry fallback only";
             visionPortal = null;
-            return;
         }
 
         aprilTagService = null;
@@ -80,7 +80,8 @@ public class AprilTagVisionService {
 
     public AprilTagService getAprilTagService(double timeoutSeconds) {
         if (aprilTagProcessor == null) {
-            throw new IllegalStateException("AprilTagVisionService.initialize() must be called before getAprilTagService()");
+            aprilTagService = new AprilTagService(null, timeoutSeconds);
+            return aprilTagService;
         }
         if (aprilTagService == null) {
             aprilTagService = new AprilTagService(aprilTagProcessor, timeoutSeconds);
@@ -128,15 +129,18 @@ public class AprilTagVisionService {
     // -------------------------------------------------------------------------
 
     private void applyTunedExposure(int exposureMs, int gain) {
+        if (visionPortal == null) {
+            healthDetail = "Camera unavailable; running odometry fallback only";
+            return;
+        }
+
         boolean ok = setManualExposure(exposureMs, gain);
         if (ok) {
             health = CameraHealth.EXPOSURE_SET;
             healthDetail = String.format("Exposure=%dms Gain=%d", exposureMs, gain);
         } else {
-            health = (health == CameraHealth.PORTAL_BUILT)
-                    ? CameraHealth.EXPOSURE_FAILED
-                    : health;
-            healthDetail = "Exposure apply failed (camera ok? stop requested?)";
+            health = (health == CameraHealth.PORTAL_BUILT) ? CameraHealth.EXPOSURE_FAILED : health;
+            healthDetail = "Camera unavailable or exposure failed; running odometry fallback only";
         }
     }
 


### PR DESCRIPTION
# fix(p3): harden AprilTag camera fallback for teleop init

## Summary

This PR hardens the P3 camera fallback path so TeleOp can initialize cleanly even when the AprilTag camera is not mounted on the robot. The change is intentionally narrow and contains only the camera fallback robustness fix.

## What changed

- Updated `AprilTagVisionService` to degrade gracefully when `Webcam 1` / `VisionPortal` is unavailable
- Updated `AprilTagService` to tolerate a missing processor so OpModes can still initialize without a mounted camera
- Added explicit init-time telemetry:
  - `Camera unavailable; running odometry fallback only`

## Behavior impact

### What changed
- TeleOp no longer throws an uncaught exception during init when the camera is missing
- Camera-dependent turret behavior stays in odometry fallback mode until the camera is available

### What did not change
- Normal behavior remains unchanged when the camera is present
- This PR does not alter drive, shooter, intake, or autonomous path logic

## Verification

- `:TeamCode:assembleDebug`
- Deployed and tested `RedGoalSide1` autonomous
- Deployed and tested TeleOp handoff

## Risk/rollback

1. Revert this single commit if camera fallback behavior needs to be removed
2. Restore the previous hard-fail camera init path if required
3. No other P3 work needs to be rolled back because it was merged separately

## Notes

- This PR contains only one commit
- Previous P3 changes are already merged into the umbrella branch
- This follow-up is limited to init-time camera fallback hardening