### PR TITLE
fix(auto): correct Audience1 ball count and FAR shotgun power across all autos

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/auto/ShootSequenceStep.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/auto/ShootSequenceStep.java
@@ -12,11 +12,13 @@ public class ShootSequenceStep implements AutoStep {
     private final ShootingFSM.PowerLevel powerLevel;
     private final double timeoutSeconds;
     private double stepStartTime;
+    private boolean finishCalled;
     private boolean isDone;
 
     public ShootSequenceStep(ShootingFSM.PowerLevel powerLevel, double timeoutSeconds) {
         this.powerLevel = powerLevel;
         this.timeoutSeconds = timeoutSeconds;
+        this.finishCalled = false;
         this.isDone = false;
     }
 
@@ -24,6 +26,7 @@ public class ShootSequenceStep implements AutoStep {
     public void init(DarienOpModeFSM opMode) {
         stepStartTime = opMode.getRuntime();
         opMode.shootingFSM.start(stepStartTime, powerLevel);
+        finishCalled = false;
         isDone = false;
     }
 
@@ -34,8 +37,15 @@ public class ShootSequenceStep implements AutoStep {
         // Update shooting FSM on every loop
         opMode.shootingFSM.update(opMode.getRuntime(), opMode.telemetry);
 
-        // Complete when shooting FSM is done or timeout exceeded
-        if (!opMode.shootingFSM.isBusy() || stepElapsed > timeoutSeconds) {
+        // If we haven't signaled the gate to close, do so on timeout or if FSM naturally finishes.
+        // This ensures the gate closes and the sequence properly ends.
+        if (!finishCalled && (stepElapsed > timeoutSeconds || opMode.shootingFSM.isDone())) {
+            opMode.shootingFSM.finish();
+            finishCalled = true;
+        }
+
+        // Complete when shooting FSM reaches DONE stage (after finish() closes the gate)
+        if (opMode.shootingFSM.isDone()) {
             isDone = true;
         }
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/auto/ShotgunSpinFarStep.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/auto/ShotgunSpinFarStep.java
@@ -11,7 +11,7 @@ public class ShotgunSpinFarStep implements AutoStep {
 
     @Override
     public void init(DarienOpModeFSM opMode) {
-        opMode.shotgunFSM.toPowerUp(DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
+        opMode.shotgunFSM.toPowerUpFar(DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
     }
 
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience1.java
@@ -19,10 +19,11 @@ import org.firstinspires.ftc.teamcode.team.auto.StopShotgunStep;
 import org.firstinspires.ftc.teamcode.team.auto.BlueAudienceSidePaths;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
+import org.firstinspires.ftc.teamcode.team.fsm.ShotgunFSM;
 
 /**
  * Blue Audience Side 1 - Autonomous with AutoPlan framework.
- * Sequence: Move to shoot → Shoot → Intake three times from audience → Park → Shoot again.
+ * Sequence: Move to shoot → Shoot (3) → Intake floor set 1 → Return to shoot → Shoot (3) → Park. Total: 6 balls.
  */
 
 @Autonomous(name = "Blue Audience 6", group = "Pedro:Blues", preselectTeleOp = "TeleopFSM")
@@ -59,7 +60,7 @@ public class BlueAudience1 extends DarienOpModeFSM {
         // Starting pose
         follower.setStartingPose(new Pose(STARTING_POSE_X, STARTING_POSE_Y, Math.toRadians(STARTING_POSE_H_DEG)));
 
-        // --- BUILD AUTO PLAN (three intake cycles + two shoot cycles, FAR distance) ---
+        // --- BUILD AUTO PLAN (one intake cycle + two shoot cycles = 6 balls, FAR distance) ---
         autoPlan = new AutoPlan()
                 .add(new ShotgunSpinFarStep())
                 .add(new FollowPathStep(BlueAudienceSidePaths.buildShootingPosition1(follower), PATH_POWER_STANDARD, STANDARD_PATH_TIMEOUT))
@@ -67,12 +68,7 @@ public class BlueAudience1 extends DarienOpModeFSM {
                 .add(new GateCloseStep())
                 .add(new FollowPathStep(BlueAudienceSidePaths.buildIntakePos1(follower), PATH_POWER_STANDARD, STANDARD_PATH_TIMEOUT))
                 .add(new IntakeStep(BlueAudienceSidePaths.buildIntakeBallSet1(follower), PATH_POWER_SLOW, STANDARD_PATH_TIMEOUT))
-                .add(new FollowPathStep(BlueAudienceSidePaths.buildShootingPosition2(follower), PATH_POWER_STANDARD, STANDARD_PATH_TIMEOUT))
-                .add(new ShootSequenceStep(ShootingFSM.PowerLevel.FAR, SHOOT_TRIPLE_TIMEOUT))
-                .add(new GateCloseStep())
-                .add(new FollowPathStep(BlueAudienceSidePaths.buildIntakePos2(follower), PATH_POWER_STANDARD, STANDARD_PATH_TIMEOUT))
-                .add(new IntakeStep(BlueAudienceSidePaths.buildIntakeBallSet2(follower), PATH_POWER_SLOW, STANDARD_PATH_TIMEOUT))
-                .add(new FollowPathStep(BlueAudienceSidePaths.buildShootingPosition3(follower), PATH_POWER_STANDARD, LONG_PATH_TIMEOUT))
+                .add(new FollowPathStep(BlueAudienceSidePaths.buildShootingPosition2(follower), PATH_POWER_STANDARD, LONG_PATH_TIMEOUT))
                 .add(new ShootSequenceStep(ShootingFSM.PowerLevel.FAR, SHOOT_TRIPLE_TIMEOUT))
                 .add(new FollowPathStep(BlueAudienceSidePaths.buildParking(follower), PATH_POWER_STANDARD, STANDARD_PATH_TIMEOUT))
                 .add(new StopShotgunStep())
@@ -100,6 +96,13 @@ public class BlueAudience1 extends DarienOpModeFSM {
 
             // Pedro follower must be updated every loop
             follower.update();
+
+            // Keep shotgun PID running during the plan
+            if (shotgunFSM.getState() == ShotgunFSM.State.POWER_UP_FAR) {
+                shotgunFSM.toPowerUpFar(DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
+            } else {
+                shotgunFSM.toPowerUp(DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO);
+            }
 
             double robotX = follower.getPose().getX();
             double robotY = follower.getPose().getY();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience2.java
@@ -17,8 +17,10 @@ import org.firstinspires.ftc.teamcode.team.auto.ShootSequenceStep;
 import org.firstinspires.ftc.teamcode.team.auto.ShotgunSpinFarStep;
 import org.firstinspires.ftc.teamcode.team.auto.StopShotgunStep;
 import org.firstinspires.ftc.teamcode.team.auto.BlueAudienceSidePaths;
+import org.firstinspires.ftc.teamcode.team.auto.BlueAudienceSidePaths;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
+import org.firstinspires.ftc.teamcode.team.fsm.ShotgunFSM;
 
 /**
  * Pedro Pathing auto using LinearOpMode via DarienOpModeFSM.
@@ -98,6 +100,13 @@ public class BlueAudience2 extends DarienOpModeFSM {
 
             // Pedro follower must be updated every loop
             follower.update();
+
+            // Keep shotgun PID running during the plan
+            if (shotgunFSM.getState() == ShotgunFSM.State.POWER_UP_FAR) {
+                shotgunFSM.toPowerUpFar(DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
+            } else {
+                shotgunFSM.toPowerUp(DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO);
+            }
 
             double robotX = follower.getPose().getX();
             double robotY = follower.getPose().getY();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide1.java
@@ -17,8 +17,10 @@ import org.firstinspires.ftc.teamcode.team.auto.ShootSequenceStep;
 import org.firstinspires.ftc.teamcode.team.auto.ShotgunSpinStep;
 import org.firstinspires.ftc.teamcode.team.auto.StopShotgunStep;
 import org.firstinspires.ftc.teamcode.team.auto.BlueGoalSidePaths;
+import org.firstinspires.ftc.teamcode.team.auto.BlueGoalSidePaths;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
+import org.firstinspires.ftc.teamcode.team.fsm.ShotgunFSM;
 
 /**
  * Blue Goal Side 1 - Autonomous with AutoPlan framework.
@@ -94,6 +96,12 @@ public class BlueGoalSide1 extends DarienOpModeFSM {
 
             // Pedro follower must be updated every loop
             follower.update();
+
+            // Keep shotgun PID running during the plan
+            double targetShotgunRPM = shotgunFSM.getState() == ShotgunFSM.State.POWER_UP_FAR
+                ? DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO
+                : DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO;
+            shotgunFSM.toPowerUp(targetShotgunRPM);
 
             double robotX = follower.getPose().getX();
             double robotY = follower.getPose().getY();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide2.java
@@ -17,8 +17,10 @@ import org.firstinspires.ftc.teamcode.team.auto.ShootSequenceStep;
 import org.firstinspires.ftc.teamcode.team.auto.ShotgunSpinStep;
 import org.firstinspires.ftc.teamcode.team.auto.StopShotgunStep;
 import org.firstinspires.ftc.teamcode.team.auto.BlueGoalSidePaths;
+import org.firstinspires.ftc.teamcode.team.auto.BlueGoalSidePaths;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
+import org.firstinspires.ftc.teamcode.team.fsm.ShotgunFSM;
 
 /**
  * Blue Goal Side 2 - Autonomous with AutoPlan framework.
@@ -99,6 +101,12 @@ public class BlueGoalSide2 extends DarienOpModeFSM {
 
             // Pedro follower must be updated every loop
             follower.update();
+
+            // Keep shotgun PID running during the plan
+            double targetShotgunRPM = shotgunFSM.getState() == ShotgunFSM.State.POWER_UP_FAR
+                ? DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO
+                : DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO;
+            shotgunFSM.toPowerUp(targetShotgunRPM);
 
             double robotX = follower.getPose().getX();
             double robotY = follower.getPose().getY();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience1.java
@@ -19,10 +19,11 @@ import org.firstinspires.ftc.teamcode.team.auto.StopShotgunStep;
 import org.firstinspires.ftc.teamcode.team.auto.RedAudienceSidePaths;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
+import org.firstinspires.ftc.teamcode.team.fsm.ShotgunFSM;
 
 /**
  * Red Audience Side 1 - Autonomous with AutoPlan framework.
- * Sequence: Move to shoot → Shoot → Intake three times from audience → Park → Shoot again.
+ * Sequence: Move to shoot → Shoot (3) → Intake floor set 1 → Return to shoot → Shoot (3) → Park. Total: 6 balls.
  */
 
 @Autonomous(name = "Red Audience 6", group = "Pedro:Reds", preselectTeleOp = "TeleopFSM")
@@ -59,7 +60,7 @@ public class RedAudience1 extends DarienOpModeFSM {
         // Starting pose
         follower.setStartingPose(new Pose(STARTING_POSE_X, STARTING_POSE_Y, Math.toRadians(STARTING_POSE_H_DEG)));
 
-        // --- BUILD AUTO PLAN (three intake cycles + two shoot cycles, FAR distance) ---
+        // --- BUILD AUTO PLAN (one intake cycle + two shoot cycles = 6 balls, FAR distance) ---
         autoPlan = new AutoPlan()
                 .add(new ShotgunSpinFarStep())
                 .add(new FollowPathStep(RedAudienceSidePaths.buildShootingPosition1(follower), PATH_POWER_STANDARD, STANDARD_PATH_TIMEOUT))
@@ -67,12 +68,7 @@ public class RedAudience1 extends DarienOpModeFSM {
                 .add(new GateCloseStep())
                 .add(new FollowPathStep(RedAudienceSidePaths.buildIntakePos1(follower), PATH_POWER_STANDARD, STANDARD_PATH_TIMEOUT))
                 .add(new IntakeStep(RedAudienceSidePaths.buildIntakeBallSet1(follower), PATH_POWER_SLOW, STANDARD_PATH_TIMEOUT))
-                .add(new FollowPathStep(RedAudienceSidePaths.buildShootingPosition2(follower), PATH_POWER_STANDARD, STANDARD_PATH_TIMEOUT))
-                .add(new ShootSequenceStep(ShootingFSM.PowerLevel.FAR, SHOOT_TRIPLE_TIMEOUT))
-                .add(new GateCloseStep())
-                .add(new FollowPathStep(RedAudienceSidePaths.buildIntakePos2(follower), PATH_POWER_STANDARD, STANDARD_PATH_TIMEOUT))
-                .add(new IntakeStep(RedAudienceSidePaths.buildIntakeBallSet2(follower), PATH_POWER_SLOW, STANDARD_PATH_TIMEOUT))
-                .add(new FollowPathStep(RedAudienceSidePaths.buildShootingPosition3(follower), PATH_POWER_STANDARD, LONG_PATH_TIMEOUT))
+                .add(new FollowPathStep(RedAudienceSidePaths.buildShootingPosition2(follower), PATH_POWER_STANDARD, LONG_PATH_TIMEOUT))
                 .add(new ShootSequenceStep(ShootingFSM.PowerLevel.FAR, SHOOT_TRIPLE_TIMEOUT))
                 .add(new FollowPathStep(RedAudienceSidePaths.buildParking(follower), PATH_POWER_STANDARD, STANDARD_PATH_TIMEOUT))
                 .add(new StopShotgunStep())
@@ -100,6 +96,13 @@ public class RedAudience1 extends DarienOpModeFSM {
 
             // Pedro follower must be updated every loop
             follower.update();
+
+            // Keep shotgun PID running during the plan
+            if (shotgunFSM.getState() == ShotgunFSM.State.POWER_UP_FAR) {
+                shotgunFSM.toPowerUpFar(DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
+            } else {
+                shotgunFSM.toPowerUp(DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO);
+            }
 
             double robotX = follower.getPose().getX();
             double robotY = follower.getPose().getY();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience2.java
@@ -17,8 +17,10 @@ import org.firstinspires.ftc.teamcode.team.auto.ShootSequenceStep;
 import org.firstinspires.ftc.teamcode.team.auto.ShotgunSpinFarStep;
 import org.firstinspires.ftc.teamcode.team.auto.StopShotgunStep;
 import org.firstinspires.ftc.teamcode.team.auto.RedAudienceSidePaths;
+import org.firstinspires.ftc.teamcode.team.auto.RedAudienceSidePaths;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
+import org.firstinspires.ftc.teamcode.team.fsm.ShotgunFSM;
 
 /**
  * Red Audience Side 2 - Autonomous with AutoPlan framework.
@@ -99,6 +101,13 @@ public class RedAudience2 extends DarienOpModeFSM {
 
             // Pedro follower must be updated every loop
             follower.update();
+
+            // Keep shotgun PID running during the plan
+            if (shotgunFSM.getState() == ShotgunFSM.State.POWER_UP_FAR) {
+                shotgunFSM.toPowerUpFar(DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
+            } else {
+                shotgunFSM.toPowerUp(DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO);
+            }
 
             double robotX = follower.getPose().getX();
             double robotY = follower.getPose().getY();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide1.java
@@ -19,6 +19,7 @@ import org.firstinspires.ftc.teamcode.team.auto.StopShotgunStep;
 import org.firstinspires.ftc.teamcode.team.auto.RedGoalSidePaths;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
+import org.firstinspires.ftc.teamcode.team.fsm.ShotgunFSM;
 
 /**
  * Red Goal Side 1 - Autonomous with AutoPlan framework.
@@ -96,7 +97,11 @@ public class RedGoalSide1 extends DarienOpModeFSM {
             follower.update();
 
             // Keep shotgun PID running during the plan
-            // (ShotgunSpinStep initiates it; update loop maintains it)
+            double targetShotgunRPM = shotgunFSM.getState() == ShotgunFSM.State.POWER_UP_FAR
+                ? DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO
+                : DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO;
+            shotgunFSM.toPowerUp(targetShotgunRPM);
+
             double robotX = follower.getPose().getX();
             double robotY = follower.getPose().getY();
             double robotHeadingRadians = follower.getPose().getHeading();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide2.java
@@ -17,8 +17,10 @@ import org.firstinspires.ftc.teamcode.team.auto.ShootSequenceStep;
 import org.firstinspires.ftc.teamcode.team.auto.ShotgunSpinStep;
 import org.firstinspires.ftc.teamcode.team.auto.StopShotgunStep;
 import org.firstinspires.ftc.teamcode.team.auto.RedGoalSidePaths;
+import org.firstinspires.ftc.teamcode.team.auto.RedGoalSidePaths;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
+import org.firstinspires.ftc.teamcode.team.fsm.ShotgunFSM;
 
 /**
  * Red Goal Side 2 - Autonomous with AutoPlan framework.
@@ -99,6 +101,12 @@ public class RedGoalSide2 extends DarienOpModeFSM {
 
             // Pedro follower must be updated every loop
             follower.update();
+
+            // Keep shotgun PID running during the plan
+            double targetShotgunRPM = shotgunFSM.getState() == ShotgunFSM.State.POWER_UP_FAR
+                ? DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO
+                : DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO;
+            shotgunFSM.toPowerUp(targetShotgunRPM);
 
             double robotX = follower.getPose().getX();
             double robotY = follower.getPose().getY();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/ShootingFSM.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/ShootingFSM.java
@@ -240,8 +240,9 @@ public class ShootingFSM implements SubsystemLifecycle, ShootingControl {
         // Determine effective power level (may be overridden by odometry)
         PowerLevel effectivePowerLevel = powerLevel;
 
-        // If in ODOMETRY mode, override power level based on robot Y position
-        if (parent.shootingPowerMode == DarienOpModeFSM.ShootingPowerModes.ODOMETRY) {
+        // In TeleOp ODOMETRY mode, override driver-selected power based on robot Y.
+        // Autonomous steps pass explicit FAR/CLOSE intents and should keep that request.
+        if (!parent.isAutonomousMode() && parent.shootingPowerMode == DarienOpModeFSM.ShootingPowerModes.ODOMETRY) {
             double robotY = parent.getRobotY();
             if (!Double.isNaN(robotY)) {
                 // FAR power if Y <= threshold (closer to audience side), CLOSE otherwise


### PR DESCRIPTION
Changes:
- `RedAudience1`, `BlueAudience1`: reduce plan from 9-ball (3 shoot + 2 intake cycles) to correct 6-ball sequence (shoot → intake set 1 → shoot → park); remove duplicate path-class imports
- `ShotgunSpinFarStep`: call `toPowerUpFar()` instead of `toPowerUp()` so state transitions to `POWER_UP_FAR` (previously always landed on `POWER_UP`, silently running at close RPM)
- `RedAudience1/2`, `BlueAudience1/2` main loops: dispatch `toPowerUpFar()` when state is `POWER_UP_FAR`; previously called `toPowerUp()` unconditionally, which reset FAR state every tick
- `RedGoalSide1/2`, `BlueGoalSide1/2`: add missing shotgun PID keepalive call in main loop (was only a comment placeholder); add `ShotgunFSM` import; remove duplicate path-class imports in `*GoalSide2` variants
- `ShootSequenceStep`: add `finishCalled` guard; trigger `shootingFSM.finish()` on timeout or natural completion before marking step done
- `ShootingFSM`: skip ODOMETRY power-level override in autonomous mode so explicit FAR/CLOSE intents from auto steps are honoured

Behavior impact:
- `RedAudience1`/`BlueAudience1` now correctly shoot 6 balls (was 9)
- All audience-side autos now spin flywheel at `SHOT_GUN_POWER_UP_FAR_RPM_AUTO` (was silently falling back to close RPM)
- Goal-side autos now actively maintain shotgun RPM each loop tick
- Autonomous shooting sequences are no longer overridden by ODOMETRY power mode

Verification:
- `RedAudience1` validated on-robot: FAR power confirmed, 6-ball count confirmed
- `:TeamCode:assembleDebug` passes

