### PR TITLE
refactor(p5): extract tuning constants into scoped config classes

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/auto/ShotgunSpinFarStep.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/auto/ShotgunSpinFarStep.java
@@ -1,6 +1,7 @@
 package org.firstinspires.ftc.teamcode.team.auto;
 
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
+import org.firstinspires.ftc.teamcode.team.config.ShooterConfig;
 
 /**
  * Step to start shotgun spinning at FAR RPM (for audience side).
@@ -11,7 +12,7 @@ public class ShotgunSpinFarStep implements AutoStep {
 
     @Override
     public void init(DarienOpModeFSM opMode) {
-        opMode.shotgunFSM.toPowerUpFar(DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
+        opMode.shotgunFSM.toPowerUpFar(ShooterConfig.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
     }
 
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/auto/ShotgunSpinStep.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/auto/ShotgunSpinStep.java
@@ -1,6 +1,7 @@
 package org.firstinspires.ftc.teamcode.team.auto;
 
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
+import org.firstinspires.ftc.teamcode.team.config.ShooterConfig;
 
 /**
  * Step to start shotgun spinning at autonomous RPM.
@@ -11,7 +12,7 @@ public class ShotgunSpinStep implements AutoStep {
 
     @Override
     public void init(DarienOpModeFSM opMode) {
-        opMode.shotgunFSM.toPowerUp(DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO);
+        opMode.shotgunFSM.toPowerUp(ShooterConfig.SHOT_GUN_POWER_UP_RPM_AUTO);
     }
 
     @Override

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience1.java
@@ -17,6 +17,9 @@ import org.firstinspires.ftc.teamcode.team.auto.ShootSequenceStep;
 import org.firstinspires.ftc.teamcode.team.auto.ShotgunSpinFarStep;
 import org.firstinspires.ftc.teamcode.team.auto.StopShotgunStep;
 import org.firstinspires.ftc.teamcode.team.auto.BlueAudienceSidePaths;
+import org.firstinspires.ftc.teamcode.team.config.ShooterConfig;
+import org.firstinspires.ftc.teamcode.team.config.TurretConfig;
+import org.firstinspires.ftc.teamcode.team.config.VisionConfig;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShotgunFSM;
@@ -43,8 +46,8 @@ public class BlueAudience1 extends DarienOpModeFSM {
 
     private AutoPlan autoPlan;
     private Timer planTimer;
-    public double targetGoalX = DarienOpModeFSM.GOAL_BLUE_X;
-    public double targetGoalY = DarienOpModeFSM.GOAL_BLUE_Y;
+    public double targetGoalX = TurretConfig.GOAL_BLUE_X;
+    public double targetGoalY = TurretConfig.GOAL_BLUE_Y;
 
     @Override
     public void runOpMode() throws InterruptedException {
@@ -89,7 +92,7 @@ public class BlueAudience1 extends DarienOpModeFSM {
         if (isStopRequested()) return;
 
         autoPlan.init(this);
-        targetGoalId = APRILTAG_ID_GOAL_BLUE;
+        targetGoalId = VisionConfig.APRILTAG_ID_GOAL_BLUE;
 
         // --- MAIN AUTONOMOUS LOOP ---
         while (opModeIsActive() && !isStopRequested()) {
@@ -99,9 +102,9 @@ public class BlueAudience1 extends DarienOpModeFSM {
 
             // Keep shotgun PID running during the plan
             if (shotgunFSM.getState() == ShotgunFSM.State.POWER_UP_FAR) {
-                shotgunFSM.toPowerUpFar(DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
+                shotgunFSM.toPowerUpFar(ShooterConfig.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
             } else {
-                shotgunFSM.toPowerUp(DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO);
+                shotgunFSM.toPowerUp(ShooterConfig.SHOT_GUN_POWER_UP_RPM_AUTO);
             }
 
             double robotX = follower.getPose().getX();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueAudience2.java
@@ -17,7 +17,9 @@ import org.firstinspires.ftc.teamcode.team.auto.ShootSequenceStep;
 import org.firstinspires.ftc.teamcode.team.auto.ShotgunSpinFarStep;
 import org.firstinspires.ftc.teamcode.team.auto.StopShotgunStep;
 import org.firstinspires.ftc.teamcode.team.auto.BlueAudienceSidePaths;
-import org.firstinspires.ftc.teamcode.team.auto.BlueAudienceSidePaths;
+import org.firstinspires.ftc.teamcode.team.config.ShooterConfig;
+import org.firstinspires.ftc.teamcode.team.config.TurretConfig;
+import org.firstinspires.ftc.teamcode.team.config.VisionConfig;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShotgunFSM;
@@ -43,8 +45,8 @@ public class BlueAudience2 extends DarienOpModeFSM {
 
     private AutoPlan autoPlan;
     private Timer planTimer;
-    public double targetGoalX = DarienOpModeFSM.GOAL_BLUE_X;
-    public double targetGoalY = DarienOpModeFSM.GOAL_BLUE_Y;
+    public double targetGoalX = TurretConfig.GOAL_BLUE_X;
+    public double targetGoalY = TurretConfig.GOAL_BLUE_Y;
 
     @Override
     public void runOpMode() throws InterruptedException {
@@ -93,7 +95,7 @@ public class BlueAudience2 extends DarienOpModeFSM {
         if (isStopRequested()) return;
 
         autoPlan.init(this);
-        targetGoalId = APRILTAG_ID_GOAL_BLUE;
+        targetGoalId = VisionConfig.APRILTAG_ID_GOAL_BLUE;
 
         // --- MAIN AUTONOMOUS LOOP ---
         while (opModeIsActive() && !isStopRequested()) {
@@ -103,9 +105,9 @@ public class BlueAudience2 extends DarienOpModeFSM {
 
             // Keep shotgun PID running during the plan
             if (shotgunFSM.getState() == ShotgunFSM.State.POWER_UP_FAR) {
-                shotgunFSM.toPowerUpFar(DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
+                shotgunFSM.toPowerUpFar(ShooterConfig.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
             } else {
-                shotgunFSM.toPowerUp(DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO);
+                shotgunFSM.toPowerUp(ShooterConfig.SHOT_GUN_POWER_UP_RPM_AUTO);
             }
 
             double robotX = follower.getPose().getX();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide1.java
@@ -17,7 +17,9 @@ import org.firstinspires.ftc.teamcode.team.auto.ShootSequenceStep;
 import org.firstinspires.ftc.teamcode.team.auto.ShotgunSpinStep;
 import org.firstinspires.ftc.teamcode.team.auto.StopShotgunStep;
 import org.firstinspires.ftc.teamcode.team.auto.BlueGoalSidePaths;
-import org.firstinspires.ftc.teamcode.team.auto.BlueGoalSidePaths;
+import org.firstinspires.ftc.teamcode.team.config.ShooterConfig;
+import org.firstinspires.ftc.teamcode.team.config.TurretConfig;
+import org.firstinspires.ftc.teamcode.team.config.VisionConfig;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShotgunFSM;
@@ -44,8 +46,8 @@ public class BlueGoalSide1 extends DarienOpModeFSM {
 
     private AutoPlan autoPlan;
     private Timer planTimer;
-    public double targetGoalX = DarienOpModeFSM.GOAL_BLUE_X;
-    public double targetGoalY = DarienOpModeFSM.GOAL_BLUE_Y;
+    public double targetGoalX = TurretConfig.GOAL_BLUE_X;
+    public double targetGoalY = TurretConfig.GOAL_BLUE_Y;
 
     @Override
     public void runOpMode() throws InterruptedException {
@@ -89,7 +91,7 @@ public class BlueGoalSide1 extends DarienOpModeFSM {
         if (isStopRequested()) return;
 
         autoPlan.init(this);
-        targetGoalId = APRILTAG_ID_GOAL_BLUE;
+        targetGoalId = VisionConfig.APRILTAG_ID_GOAL_BLUE;
 
         // --- MAIN AUTONOMOUS LOOP ---
         while (opModeIsActive() && !isStopRequested()) {
@@ -99,8 +101,8 @@ public class BlueGoalSide1 extends DarienOpModeFSM {
 
             // Keep shotgun PID running during the plan
             double targetShotgunRPM = shotgunFSM.getState() == ShotgunFSM.State.POWER_UP_FAR
-                ? DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO
-                : DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO;
+                ? ShooterConfig.SHOT_GUN_POWER_UP_FAR_RPM_AUTO
+                : ShooterConfig.SHOT_GUN_POWER_UP_RPM_AUTO;
             shotgunFSM.toPowerUp(targetShotgunRPM);
 
             double robotX = follower.getPose().getX();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/BlueGoalSide2.java
@@ -17,7 +17,9 @@ import org.firstinspires.ftc.teamcode.team.auto.ShootSequenceStep;
 import org.firstinspires.ftc.teamcode.team.auto.ShotgunSpinStep;
 import org.firstinspires.ftc.teamcode.team.auto.StopShotgunStep;
 import org.firstinspires.ftc.teamcode.team.auto.BlueGoalSidePaths;
-import org.firstinspires.ftc.teamcode.team.auto.BlueGoalSidePaths;
+import org.firstinspires.ftc.teamcode.team.config.ShooterConfig;
+import org.firstinspires.ftc.teamcode.team.config.TurretConfig;
+import org.firstinspires.ftc.teamcode.team.config.VisionConfig;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShotgunFSM;
@@ -44,8 +46,8 @@ public class BlueGoalSide2 extends DarienOpModeFSM {
 
     private AutoPlan autoPlan;
     private Timer planTimer;
-    public double targetGoalX = DarienOpModeFSM.GOAL_BLUE_X;
-    public double targetGoalY = DarienOpModeFSM.GOAL_BLUE_Y;
+    public double targetGoalX = TurretConfig.GOAL_BLUE_X;
+    public double targetGoalY = TurretConfig.GOAL_BLUE_Y;
 
     @Override
     public void runOpMode() throws InterruptedException {
@@ -94,7 +96,7 @@ public class BlueGoalSide2 extends DarienOpModeFSM {
         if (isStopRequested()) return;
 
         autoPlan.init(this);
-        targetGoalId = APRILTAG_ID_GOAL_BLUE;
+        targetGoalId = VisionConfig.APRILTAG_ID_GOAL_BLUE;
 
         // --- MAIN AUTONOMOUS LOOP ---
         while (opModeIsActive() && !isStopRequested()) {
@@ -104,8 +106,8 @@ public class BlueGoalSide2 extends DarienOpModeFSM {
 
             // Keep shotgun PID running during the plan
             double targetShotgunRPM = shotgunFSM.getState() == ShotgunFSM.State.POWER_UP_FAR
-                ? DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO
-                : DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO;
+                ? ShooterConfig.SHOT_GUN_POWER_UP_FAR_RPM_AUTO
+                : ShooterConfig.SHOT_GUN_POWER_UP_RPM_AUTO;
             shotgunFSM.toPowerUp(targetShotgunRPM);
 
             double robotX = follower.getPose().getX();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience1.java
@@ -17,6 +17,9 @@ import org.firstinspires.ftc.teamcode.team.auto.ShootSequenceStep;
 import org.firstinspires.ftc.teamcode.team.auto.ShotgunSpinFarStep;
 import org.firstinspires.ftc.teamcode.team.auto.StopShotgunStep;
 import org.firstinspires.ftc.teamcode.team.auto.RedAudienceSidePaths;
+import org.firstinspires.ftc.teamcode.team.config.ShooterConfig;
+import org.firstinspires.ftc.teamcode.team.config.TurretConfig;
+import org.firstinspires.ftc.teamcode.team.config.VisionConfig;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShotgunFSM;
@@ -43,8 +46,8 @@ public class RedAudience1 extends DarienOpModeFSM {
 
     private AutoPlan autoPlan;
     private Timer planTimer;
-    public double targetGoalX = DarienOpModeFSM.GOAL_RED_X;
-    public double targetGoalY = DarienOpModeFSM.GOAL_RED_Y;
+    public double targetGoalX = TurretConfig.GOAL_RED_X;
+    public double targetGoalY = TurretConfig.GOAL_RED_Y;
 
     @Override
     public void runOpMode() throws InterruptedException {
@@ -89,7 +92,7 @@ public class RedAudience1 extends DarienOpModeFSM {
         if (isStopRequested()) return;
 
         autoPlan.init(this);
-        targetGoalId = APRILTAG_ID_GOAL_RED;
+        targetGoalId = VisionConfig.APRILTAG_ID_GOAL_RED;
 
         // --- MAIN AUTONOMOUS LOOP ---
         while (opModeIsActive() && !isStopRequested()) {
@@ -99,9 +102,9 @@ public class RedAudience1 extends DarienOpModeFSM {
 
             // Keep shotgun PID running during the plan
             if (shotgunFSM.getState() == ShotgunFSM.State.POWER_UP_FAR) {
-                shotgunFSM.toPowerUpFar(DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
+                shotgunFSM.toPowerUpFar(ShooterConfig.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
             } else {
-                shotgunFSM.toPowerUp(DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO);
+                shotgunFSM.toPowerUp(ShooterConfig.SHOT_GUN_POWER_UP_RPM_AUTO);
             }
 
             double robotX = follower.getPose().getX();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedAudience2.java
@@ -17,7 +17,9 @@ import org.firstinspires.ftc.teamcode.team.auto.ShootSequenceStep;
 import org.firstinspires.ftc.teamcode.team.auto.ShotgunSpinFarStep;
 import org.firstinspires.ftc.teamcode.team.auto.StopShotgunStep;
 import org.firstinspires.ftc.teamcode.team.auto.RedAudienceSidePaths;
-import org.firstinspires.ftc.teamcode.team.auto.RedAudienceSidePaths;
+import org.firstinspires.ftc.teamcode.team.config.ShooterConfig;
+import org.firstinspires.ftc.teamcode.team.config.TurretConfig;
+import org.firstinspires.ftc.teamcode.team.config.VisionConfig;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShotgunFSM;
@@ -44,8 +46,8 @@ public class RedAudience2 extends DarienOpModeFSM {
 
     private AutoPlan autoPlan;
     private Timer planTimer;
-    public double targetGoalX = DarienOpModeFSM.GOAL_RED_X;
-    public double targetGoalY = DarienOpModeFSM.GOAL_RED_Y;
+    public double targetGoalX = TurretConfig.GOAL_RED_X;
+    public double targetGoalY = TurretConfig.GOAL_RED_Y;
 
     @Override
     public void runOpMode() throws InterruptedException {
@@ -94,7 +96,7 @@ public class RedAudience2 extends DarienOpModeFSM {
         if (isStopRequested()) return;
 
         autoPlan.init(this);
-        targetGoalId = APRILTAG_ID_GOAL_RED;
+        targetGoalId = VisionConfig.APRILTAG_ID_GOAL_RED;
 
         // --- MAIN AUTONOMOUS LOOP ---
         while (opModeIsActive() && !isStopRequested()) {
@@ -104,9 +106,9 @@ public class RedAudience2 extends DarienOpModeFSM {
 
             // Keep shotgun PID running during the plan
             if (shotgunFSM.getState() == ShotgunFSM.State.POWER_UP_FAR) {
-                shotgunFSM.toPowerUpFar(DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
+                shotgunFSM.toPowerUpFar(ShooterConfig.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
             } else {
-                shotgunFSM.toPowerUp(DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO);
+                shotgunFSM.toPowerUp(ShooterConfig.SHOT_GUN_POWER_UP_RPM_AUTO);
             }
 
             double robotX = follower.getPose().getX();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide1.java
@@ -17,6 +17,9 @@ import org.firstinspires.ftc.teamcode.team.auto.ShootSequenceStep;
 import org.firstinspires.ftc.teamcode.team.auto.ShotgunSpinStep;
 import org.firstinspires.ftc.teamcode.team.auto.StopShotgunStep;
 import org.firstinspires.ftc.teamcode.team.auto.RedGoalSidePaths;
+import org.firstinspires.ftc.teamcode.team.config.ShooterConfig;
+import org.firstinspires.ftc.teamcode.team.config.TurretConfig;
+import org.firstinspires.ftc.teamcode.team.config.VisionConfig;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShotgunFSM;
@@ -43,8 +46,8 @@ public class RedGoalSide1 extends DarienOpModeFSM {
 
     private AutoPlan autoPlan;
     private Timer planTimer;
-    public double targetGoalX = DarienOpModeFSM.GOAL_RED_X;
-    public double targetGoalY = DarienOpModeFSM.GOAL_RED_Y;
+    public double targetGoalX = TurretConfig.GOAL_RED_X;
+    public double targetGoalY = TurretConfig.GOAL_RED_Y;
 
     @Override
     public void runOpMode() throws InterruptedException {
@@ -88,7 +91,7 @@ public class RedGoalSide1 extends DarienOpModeFSM {
         if (isStopRequested()) return;
 
         autoPlan.init(this);
-        targetGoalId = APRILTAG_ID_GOAL_RED;
+        targetGoalId = VisionConfig.APRILTAG_ID_GOAL_RED;
 
         // --- MAIN AUTONOMOUS LOOP ---
         while (opModeIsActive() && !isStopRequested()) {
@@ -98,8 +101,8 @@ public class RedGoalSide1 extends DarienOpModeFSM {
 
             // Keep shotgun PID running during the plan
             double targetShotgunRPM = shotgunFSM.getState() == ShotgunFSM.State.POWER_UP_FAR
-                ? DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO
-                : DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO;
+                ? ShooterConfig.SHOT_GUN_POWER_UP_FAR_RPM_AUTO
+                : ShooterConfig.SHOT_GUN_POWER_UP_RPM_AUTO;
             shotgunFSM.toPowerUp(targetShotgunRPM);
 
             double robotX = follower.getPose().getX();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide2.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/autosPedroPathing/RedGoalSide2.java
@@ -17,7 +17,9 @@ import org.firstinspires.ftc.teamcode.team.auto.ShootSequenceStep;
 import org.firstinspires.ftc.teamcode.team.auto.ShotgunSpinStep;
 import org.firstinspires.ftc.teamcode.team.auto.StopShotgunStep;
 import org.firstinspires.ftc.teamcode.team.auto.RedGoalSidePaths;
-import org.firstinspires.ftc.teamcode.team.auto.RedGoalSidePaths;
+import org.firstinspires.ftc.teamcode.team.config.ShooterConfig;
+import org.firstinspires.ftc.teamcode.team.config.TurretConfig;
+import org.firstinspires.ftc.teamcode.team.config.VisionConfig;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShootingFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.ShotgunFSM;
@@ -44,8 +46,8 @@ public class RedGoalSide2 extends DarienOpModeFSM {
 
     private AutoPlan autoPlan;
     private Timer planTimer;
-    public double targetGoalX = DarienOpModeFSM.GOAL_RED_X;
-    public double targetGoalY = DarienOpModeFSM.GOAL_RED_Y;
+    public double targetGoalX = TurretConfig.GOAL_RED_X;
+    public double targetGoalY = TurretConfig.GOAL_RED_Y;
 
     @Override
     public void runOpMode() throws InterruptedException {
@@ -94,7 +96,7 @@ public class RedGoalSide2 extends DarienOpModeFSM {
         if (isStopRequested()) return;
 
         autoPlan.init(this);
-        targetGoalId = APRILTAG_ID_GOAL_RED;
+        targetGoalId = VisionConfig.APRILTAG_ID_GOAL_RED;
 
         // --- MAIN AUTONOMOUS LOOP ---
         while (opModeIsActive() && !isStopRequested()) {
@@ -104,8 +106,8 @@ public class RedGoalSide2 extends DarienOpModeFSM {
 
             // Keep shotgun PID running during the plan
             double targetShotgunRPM = shotgunFSM.getState() == ShotgunFSM.State.POWER_UP_FAR
-                ? DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO
-                : DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO;
+                ? ShooterConfig.SHOT_GUN_POWER_UP_FAR_RPM_AUTO
+                : ShooterConfig.SHOT_GUN_POWER_UP_RPM_AUTO;
             shotgunFSM.toPowerUp(targetShotgunRPM);
 
             double robotX = follower.getPose().getX();

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/config/AutoConfig.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/config/AutoConfig.java
@@ -1,0 +1,32 @@
+package org.firstinspires.ftc.teamcode.team.config;
+
+import com.acmerobotics.dashboard.config.Config;
+import com.bylazar.configurables.annotations.Configurable;
+
+/**
+ * Autonomous and field-position tuning values.
+ */
+@Config
+@Configurable
+public class AutoConfig {
+
+    public static double HUMAN_PLAYER_RED_X = 0.0;
+    public static double HUMAN_PLAYER_RED_Y = 0.0;
+    public static double HUMAN_PLAYER_BLUE_X = 144.0;
+    public static double HUMAN_PLAYER_BLUE_Y = 0.0;
+
+    public static double PARK_RED_X = 39.0;
+    public static double PARK_RED_Y = 33.0;
+    public static double PARK_RED_H_DEG = 180.0;
+    public static double PARK_BLUE_X = 105.0;
+    public static double PARK_BLUE_Y = 33.0;
+    public static double PARK_BLUE_H_DEG = 0.0;
+
+    public static double AUTO_PARK_TIMEOUT = 10.0;
+    public static double AUTO_PARK_POWER = 0.7;
+    public static double AUTO_PARK_STICK_DEADZONE = 0.1;
+
+    private AutoConfig() {
+    }
+}
+

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/config/DriveConfig.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/config/DriveConfig.java
@@ -1,0 +1,30 @@
+package org.firstinspires.ftc.teamcode.team.config;
+
+import com.acmerobotics.dashboard.config.Config;
+import com.bylazar.configurables.annotations.Configurable;
+
+/**
+ * Drive + localization tuning values shared by TeleOp and autonomous.
+ */
+@Config
+@Configurable
+public class DriveConfig {
+
+    // Encoder constants for goBILDA 5203 in 4x mode.
+    public static double TICKS_PER_ROTATION = 28 * 4;
+
+    // Human-player reset origin offset from robot center.
+    public static double ROBOT_CENTER_OFFSET_X = 8.5;
+    public static double ROBOT_CENTER_OFFSET_Y = 8.25;
+
+    // TeleOp drive shaping.
+    public static double ROTATION_SCALE = 0.5;
+    public static double SPEED_SCALE = 1.0;
+    public static double SPEED_SCALE_TURN = 0.8;
+    public static double INPUT_EXPONENT = 3.0;
+    public static double DRIVE_DEADZONE = 0.1;
+
+    private DriveConfig() {
+    }
+}
+

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/config/ShooterConfig.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/config/ShooterConfig.java
@@ -1,0 +1,40 @@
+package org.firstinspires.ftc.teamcode.team.config;
+
+import com.acmerobotics.dashboard.config.Config;
+import com.bylazar.configurables.annotations.Configurable;
+
+/**
+ * Shooter and flywheel tuning values.
+ */
+@Config
+@Configurable
+public class ShooterConfig {
+
+    public static double SHOT_GUN_POWER_UP = 0.60;
+    public static double SHOT_GUN_POWER_UP_FAR = 0.64;
+    public static double SHOT_GUN_POWER_UP_RPM = 1100;
+    public static double SHOT_GUN_POWER_UP_RPM_AUTO = 1075;
+    public static double SHOT_GUN_POWER_UP_FAR_RPM_AUTO = 1350;
+    public static double SHOT_GUN_POWER_UP_FAR_RPM_TELEOP = 1350;
+    public static double SHOT_GUN_POWER_DOWN = 0.2;
+
+    public static double SHOOTING_POWER_ODOMETRY_Y_THRESHOLD = 48.0;
+    public static double SHOOT_POWER_SELECT_STICK_THRESHOLD = 0.05;
+
+    public static double SHOT_GUN_PGAIN = 0.002;
+    public static double SHOT_GUN_PGAIN2 = 0.0005;
+    public static double SHOT_GUN_IGAIN = 0.00003;
+    public static double SHOT_GUN_PDUTY_MIN = -0.5;
+    public static double SHOT_GUN_PDUTY_MAX = 1.0;
+    public static double SHOT_GUN_IDUTY_MIN = 0.0;
+    public static double SHOT_GUN_IDUTY_MAX = 1.0;
+    public static double SHOT_GUN_POWER_MIN = 0.0;
+    public static double SHOT_GUN_POWER_MAX = 1.0;
+    public static double SHOT_GUN_GAIN = 1.0;
+    public static double SHOT_GUN_MIN_RPM = 0.0;
+    public static double SHOT_GUN_MAX_RPM = 3000.0;
+
+    private ShooterConfig() {
+    }
+}
+

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/config/TurretConfig.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/config/TurretConfig.java
@@ -1,0 +1,32 @@
+package org.firstinspires.ftc.teamcode.team.config;
+
+import com.acmerobotics.dashboard.config.Config;
+import com.bylazar.configurables.annotations.Configurable;
+
+/**
+ * Turret aiming geometry and servo tuning values.
+ */
+@Config
+@Configurable
+public class TurretConfig {
+
+    public static double GOAL_RED_X = 144.0;
+    public static double GOAL_RED_Y = 144.0;
+    public static double GOAL_BLUE_X = 0.0;
+    public static double GOAL_BLUE_Y = 144.0;
+
+    public static double TURRET_GEAR_RATIO = 5.8;
+    public static double TURRET_ROTATION_INCREMENT = 0.001;
+    public static double TURRET_ROTATION_INCREMENT_FAST = 0.003;
+    public static double TURRET_POSITION_CENTER = 0.5;
+    public static double TURRET_OFFSET_DEG_RED = 1.0;
+    public static double TURRET_OFFSET_DEG_BLUE = -3.0;
+    public static double TURRET_PIVOT_OFFSET_INCHES = -1.5;
+    public static double TURRET_PIVOT_OFFSET_LATERAL_INCHES = 0.0;
+    public static double TURRET_MAX_DEG_LEFT = 150.0;
+    public static double TURRET_MAX_DEG_RIGHT = 180.0;
+
+    private TurretConfig() {
+    }
+}
+

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/config/VisionConfig.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/config/VisionConfig.java
@@ -1,0 +1,25 @@
+package org.firstinspires.ftc.teamcode.team.config;
+
+import com.acmerobotics.dashboard.config.Config;
+import com.bylazar.configurables.annotations.Configurable;
+
+/**
+ * Vision + AprilTag tuning values.
+ */
+@Config
+@Configurable
+public class VisionConfig {
+
+    public static int APRILTAG_ID_GOAL_BLUE = 20;
+    public static int APRILTAG_ID_GOAL_RED = 24;
+
+    public static int APRILTAG_EXPOSURE_MS = 6;
+    public static int APRILTAG_GAIN = 255;
+
+    public static double TIMEOUT_APRILTAG_DETECTION = 0.75;
+    public static double CAMERA_FALLBACK_TIMEOUT_MS = 500.0;
+
+    private VisionConfig() {
+    }
+}
+

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/core/RobotContainer.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/core/RobotContainer.java
@@ -3,6 +3,9 @@ package org.firstinspires.ftc.teamcode.team.core;
 import com.pedropathing.follower.Follower;
 
 import org.firstinspires.ftc.teamcode.team.MotorHelper;
+import org.firstinspires.ftc.teamcode.team.config.DriveConfig;
+import org.firstinspires.ftc.teamcode.team.config.ShooterConfig;
+import org.firstinspires.ftc.teamcode.team.config.VisionConfig;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.GateFSM;
 import org.firstinspires.ftc.teamcode.team.fsm.IntakeFSM;
@@ -48,16 +51,15 @@ public class RobotContainer {
     public void initialize() {
         hardware.initialize(opMode.hardwareMap);
         services.initialize();
-        aprilTagService = services.getVisionService().getAprilTagService(DarienOpModeFSM.TIMEOUT_APRILTAG_DETECTION);
+        aprilTagService = services.getVisionService().getAprilTagService(VisionConfig.TIMEOUT_APRILTAG_DETECTION);
 
-        motorHelper = new MotorHelper(opMode.telemetry, DarienOpModeFSM.TICKS_PER_ROTATION);
+        motorHelper = new MotorHelper(opMode.telemetry, DriveConfig.TICKS_PER_ROTATION);
         shootArtifactFSM = new ShootArtifactFSM(opMode);
         shootPatternFSM = new ShootPatternFSM(opMode);
         shotgunFSM = new ShotgunFSM(
-                DarienOpModeFSM.SHOT_GUN_POWER_UP,
-                DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR,
+                ShooterConfig.SHOT_GUN_POWER_UP,
+                ShooterConfig.SHOT_GUN_POWER_UP_FAR,
                 hardware.ejectionMotor,
-                opMode,
                 motorHelper
         );
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/core/TurretCoordinator.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/core/TurretCoordinator.java
@@ -1,6 +1,6 @@
 package org.firstinspires.ftc.teamcode.team.core;
 
-import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
+import org.firstinspires.ftc.teamcode.team.config.TurretConfig;
 import org.firstinspires.ftc.teamcode.team.fsm.TurretFSM;
 
 /**
@@ -47,11 +47,11 @@ public class TurretCoordinator {
             double targetGoalX;
             double targetGoalY;
             if ("RED".equals(autoAlliance)) {
-                targetGoalX = DarienOpModeFSM.GOAL_RED_X;
-                targetGoalY = DarienOpModeFSM.GOAL_RED_Y;
+                targetGoalX = TurretConfig.GOAL_RED_X;
+                targetGoalY = TurretConfig.GOAL_RED_Y;
             } else {
-                targetGoalX = DarienOpModeFSM.GOAL_BLUE_X;
-                targetGoalY = DarienOpModeFSM.GOAL_BLUE_Y;
+                targetGoalX = TurretConfig.GOAL_BLUE_X;
+                targetGoalY = TurretConfig.GOAL_BLUE_Y;
             }
 
             turretFSM.setPositionFromOdometry(targetGoalX, targetGoalY, robotX, robotY, robotHeadingRadians);

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/core/TurretVisionCoordinator.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/core/TurretVisionCoordinator.java
@@ -1,7 +1,7 @@
 package org.firstinspires.ftc.teamcode.team.core;
 
 import org.firstinspires.ftc.robotcore.external.Telemetry;
-import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
+import org.firstinspires.ftc.teamcode.team.config.TurretConfig;
 import org.firstinspires.ftc.teamcode.team.fsm.TurretFSM;
 import org.firstinspires.ftc.teamcode.team.services.AprilTagService;
 import org.firstinspires.ftc.vision.apriltag.AprilTagDetection;
@@ -180,10 +180,10 @@ public class TurretVisionCoordinator {
     private void applyOdometryFallback(String autoAlliance, double robotX, double robotY, double robotHeadingRadians) {
         if ("RED".equals(autoAlliance)) {
             turretFSM.setOffsetRed();
-            turretFSM.setPositionFromOdometry(DarienOpModeFSM.GOAL_RED_X, DarienOpModeFSM.GOAL_RED_Y, robotX, robotY, robotHeadingRadians);
+            turretFSM.setPositionFromOdometry(TurretConfig.GOAL_RED_X, TurretConfig.GOAL_RED_Y, robotX, robotY, robotHeadingRadians);
         } else {
             turretFSM.setOffsetBlue();
-            turretFSM.setPositionFromOdometry(DarienOpModeFSM.GOAL_BLUE_X, DarienOpModeFSM.GOAL_BLUE_Y, robotX, robotY, robotHeadingRadians);
+            turretFSM.setPositionFromOdometry(TurretConfig.GOAL_BLUE_X, TurretConfig.GOAL_BLUE_Y, robotX, robotY, robotHeadingRadians);
         }
     }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/DarienOpModeFSM.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/DarienOpModeFSM.java
@@ -11,6 +11,7 @@ import com.qualcomm.robotcore.hardware.DcMotorEx;
 import com.pedropathing.follower.Follower;
 
 import org.firstinspires.ftc.teamcode.team.core.RobotContainer;
+import org.firstinspires.ftc.teamcode.team.config.DriveConfig;
 import org.firstinspires.ftc.teamcode.team.MotorHelper;
 import org.firstinspires.ftc.teamcode.team.services.AprilTagService;
 import org.firstinspires.ftc.teamcode.team.services.AprilTagVisionService;
@@ -60,85 +61,8 @@ public abstract class DarienOpModeFSM extends LinearOpMode {
     public static final double constMult = (wheelDiameter * (Math.PI));
     public static final double inchesToEncoder = encoderResolution / constMult;
     public static final double PI = 3.1416;
-    public static final double TICKS_PER_ROTATION = 28*4; // for goBILDA 6000 rpm motor 5203. Each rotation has 28 ticks, and with 4x encoder mode, it's 28*4.
-    //public static double TICKS_PER_ROTATION = 103.8 * 4; // for goBILDA 1620 rpm motor 5202. Each rotation has 103.8 PPR at the Output Shaft, and with quadrature (4x) encoder mode, it's 103.8 * 4 = 415.2
-    public static double ROBOT_CENTER_OFFSET_X = 8.5;
-    public static double ROBOT_CENTER_OFFSET_Y = 8.25;
-
-    // HARDWARE TUNING CONSTANTS
-    public static double SHOT_GUN_POWER_UP = 0.60;
-    public static double SHOT_GUN_POWER_UP_FAR = 0.64;//66
-    public static double SHOT_GUN_POWER_UP_RPM = 1100; // tuned to 6000 rpm motor mounted vertically with small bevel gears
-    public static double SHOT_GUN_POWER_UP_RPM_AUTO = 1075;
-    public static double SHOT_GUN_POWER_UP_FAR_RPM_AUTO = 1350;// tuned to 6000 rpm motor mounted vertically with small bevel gears
-    public static double SHOT_GUN_POWER_UP_FAR_RPM_TELEOP = 1350; // tuned to 6000 rpm motor mounted vertically with small bevel gears
-    public static double SHOT_GUN_POWER_DOWN = 0.2; // tuned to 6000 rpm motor
-
-    // SHOOTING POWER ODOMETRY TUNING
-    public static double SHOOTING_POWER_ODOMETRY_Y_THRESHOLD = 48.0; // Y threshold for automatic FAR vs CLOSE power selection
-
-    // For FTC AprilTag detection with a Logitech C910 webcam,
-    // 1.0 to 1.5 seconds is typically sufficient and more reasonable than 3 seconds.
-    // Recommended timeout values:
-    //   1.0 second (1000ms): Good for typical autonomous scenarios where the camera has a clear view of tags
-    //   1.5 seconds (1500ms): More conservative, allows for slight delays in camera initialization or processing
-    //   0.5 seconds (500ms): Can work if tags are large, close, and well-lit, but may be too aggressive
-    // Factors to consider:
-    //   Camera exposure: The C910 may need 1-2 frames to adjust exposure in varying light conditions
-    //   Processing time: AprilTag detection typically runs at 10-30 FPS, so 1 second gives 10-30 detection attempts
-    //   Distance/size: Tags further away or smaller may need slightly more time
-    //   Lighting: Poor lighting may require longer timeout
-    public static double TIMEOUT_APRILTAG_DETECTION = 0.75; // seconds
-
-    // PID Constants for custom MotorHelper PID functions
-    public static double SHOT_GUN_PGAIN = 0.002;
-    public static double SHOT_GUN_PGAIN2 = 0.0005;
-    public static double SHOT_GUN_IGAIN = 0.00003;
-    public static double SHOT_GUN_PDUTY_MIN = -0.5; // SHOT_GUN_PDUTY_MIN = -0.5 may cause the PID to brake the motor if it overshoots — consider setting it to 0.0 for a flywheel since you never want reverse braking.
-    public static double SHOT_GUN_PDUTY_MAX = 1;
-    public static double SHOT_GUN_IDUTY_MIN = 0;
-    public static double SHOT_GUN_IDUTY_MAX = 1;
-    public static double SHOT_GUN_POWER_MIN = 0;
-    public static double SHOT_GUN_POWER_MAX = 1;
-    public static double SHOT_GUN_GAIN = 1;
-    public static double SHOT_GUN_MIN_RPM = 0;
-    public static double SHOT_GUN_MAX_RPM = 3000;
-
-    public final int APRILTAG_ID_GOAL_BLUE = 20;
-    public final int APRILTAG_ID_GOAL_RED = 24;
-
-    // CAMERA EXPOSURE/GAIN SETTINGS FOR APRILTAG DETECTION
-    // Low exposure (5-6ms) with high gain reduces motion blur and improves far-distance detection
-    // Tune these values using the TuneAprilTagExposure OpMode while viewing camera stream
-    public static int APRILTAG_EXPOSURE_MS = 6;  // Milliseconds (lower = less blur, start with 5-6)
-    public static int APRILTAG_GAIN = 255;       // 0-255 (higher = brighter in low light, start at max)
-
-    // FIELD GOAL POSITION CONSTANTS (in inches, Pedro Pathing coordinate system)
-    // (0,0) = left audience side (red loading zone), (72,72) = field center, (144,144) = red goal
-    public static final double GOAL_RED_X = 144;
-    public static final double GOAL_RED_Y = 144;
-    public static final double GOAL_BLUE_X = 0;
-    public static final double GOAL_BLUE_Y = 144;
-
-    // HUMAN PLAYER POSITION CONSTANTS (in inches, Pedro Pathing coordinate system)
-    public static final double HUMAN_PLAYER_RED_X = 0;
-    public static final double HUMAN_PLAYER_RED_Y = 0;
-    public static final double HUMAN_PLAYER_BLUE_X = 144;
-    public static final double HUMAN_PLAYER_BLUE_Y = 0;
-
-    // AUTO-PARK POSITION CONSTANTS (in inches + degrees, Pedro Pathing coordinate system)
-    // Tune these via FTC Dashboard or update them here for each alliance's park zone.
-    public static double PARK_RED_X = 39.0;
-    public static double PARK_RED_Y = 33.0;
-    public static double PARK_RED_H_DEG = 180.0;
-    public static double PARK_BLUE_X = 105.0;
-    public static double PARK_BLUE_Y = 33.0;
-    public static double PARK_BLUE_H_DEG = 0.0;
-    public static double AUTO_PARK_TIMEOUT = 10.0;       // seconds — safety timeout to abort auto-park
-    public static double AUTO_PARK_POWER = 0.7;          // max follower power during auto-park
-
-    // ODOMETRY AIMING TUNING
-    public static double CAMERA_FALLBACK_TIMEOUT_MS = 500; // Auto-switch to odometry after this timeout
+    // Fixed encoder geometry constants.
+    // Note: tunable drivetrain/scoring values now live under team.config.*
 
     public int targetGoalId = 0;
     protected RobotContainer robotContainer;
@@ -266,7 +190,7 @@ public abstract class DarienOpModeFSM extends LinearOpMode {
     public double getTicksPerSecond(double requestedRPM) {
         try {
             double targetRPM = requestedRPM;
-            double ticksPerSecond = (targetRPM / 60.0) * TICKS_PER_ROTATION;
+            double ticksPerSecond = (targetRPM / 60.0) * DriveConfig.TICKS_PER_ROTATION;
             return ticksPerSecond;
         }
         catch (Exception e) {
@@ -278,7 +202,7 @@ public abstract class DarienOpModeFSM extends LinearOpMode {
 
     public double getRpmFromTicksPerSecond(double ticksPerSecond) {
         try {
-            double rpm = (ticksPerSecond * 60.0) / TICKS_PER_ROTATION;
+            double rpm = (ticksPerSecond * 60.0) / DriveConfig.TICKS_PER_ROTATION;
             return rpm;
         } catch (Exception e) {
             // telemetry.addData("RPM from Ticks/Sec Error", e.getMessage());
@@ -299,7 +223,7 @@ public abstract class DarienOpModeFSM extends LinearOpMode {
     }
 
     public void displayRpmTelemetry() {
-        telemetry.addData("Actual ShotGun RPM", ejectionMotor.getVelocity() * 60 / TICKS_PER_ROTATION); // convert from ticks per second to RPM
+        telemetry.addData("Actual ShotGun RPM", ejectionMotor.getVelocity() * 60 / DriveConfig.TICKS_PER_ROTATION); // convert from ticks per second to RPM
         telemetry.addData("ejectionMotor power", ejectionMotor.getPower());
         telemetry.addData("Actual ShotGun TPS", ejectionMotor.getVelocity()); // convert from ticks per second to RPM
         telemetry.addData("Shooting Power Mode", shootingPowerMode.toString());

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/ShootArtifactFSM.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/ShootArtifactFSM.java
@@ -2,6 +2,8 @@ package org.firstinspires.ftc.teamcode.team.fsm;
 
 import com.acmerobotics.dashboard.config.Config;
 
+import org.firstinspires.ftc.teamcode.team.config.ShooterConfig;
+
 @Config
 
 public class ShootArtifactFSM {
@@ -81,10 +83,10 @@ public class ShootArtifactFSM {
 
     public void shotGun(double power) {
         //opMode.ejectionMotor.setPower(opMode.getVoltageAdjustedMotorPower(power));
-        if (power == DarienOpModeFSM.SHOT_GUN_POWER_UP) {
-            shotGunRPM(DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO);
-        } else if (power == DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR) {
-            shotGunRPM(DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
+        if (power == ShooterConfig.SHOT_GUN_POWER_UP) {
+            shotGunRPM(ShooterConfig.SHOT_GUN_POWER_UP_RPM_AUTO);
+        } else if (power == ShooterConfig.SHOT_GUN_POWER_UP_FAR) {
+            shotGunRPM(ShooterConfig.SHOT_GUN_POWER_UP_FAR_RPM_AUTO);
         }
     }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/ShootingFSM.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/ShootingFSM.java
@@ -4,6 +4,7 @@ import com.acmerobotics.dashboard.config.Config;
 import com.bylazar.configurables.annotations.Configurable;
 
 import org.firstinspires.ftc.robotcore.external.Telemetry;
+import org.firstinspires.ftc.teamcode.team.config.ShooterConfig;
 import org.firstinspires.ftc.teamcode.team.subsystems.GateControl;
 import org.firstinspires.ftc.teamcode.team.subsystems.ShooterIntakeControl;
 import org.firstinspires.ftc.teamcode.team.subsystems.ShootingControl;
@@ -246,7 +247,7 @@ public class ShootingFSM implements SubsystemLifecycle, ShootingControl {
             double robotY = parent.getRobotY();
             if (!Double.isNaN(robotY)) {
                 // FAR power if Y <= threshold (closer to audience side), CLOSE otherwise
-                effectivePowerLevel = (robotY <= DarienOpModeFSM.SHOOTING_POWER_ODOMETRY_Y_THRESHOLD)
+                effectivePowerLevel = (robotY <= ShooterConfig.SHOOTING_POWER_ODOMETRY_Y_THRESHOLD)
                     ? PowerLevel.FAR
                     : PowerLevel.CLOSE;
             }
@@ -256,13 +257,13 @@ public class ShootingFSM implements SubsystemLifecycle, ShootingControl {
         double targetRPM;
         if (effectivePowerLevel == PowerLevel.FAR) {
             targetRPM = parent.isAutonomousMode()
-                ? DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_AUTO
-                : DarienOpModeFSM.SHOT_GUN_POWER_UP_FAR_RPM_TELEOP;
+                ? ShooterConfig.SHOT_GUN_POWER_UP_FAR_RPM_AUTO
+                : ShooterConfig.SHOT_GUN_POWER_UP_FAR_RPM_TELEOP;
             shotgunFSM.toPowerUpFar(targetRPM);
         } else {
             targetRPM = parent.isAutonomousMode()
-                ? DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM_AUTO
-                : DarienOpModeFSM.SHOT_GUN_POWER_UP_RPM;
+                ? ShooterConfig.SHOT_GUN_POWER_UP_RPM_AUTO
+                : ShooterConfig.SHOT_GUN_POWER_UP_RPM;
             shotgunFSM.toPowerUp(targetRPM);
         }
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/ShotgunFSM.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/ShotgunFSM.java
@@ -3,10 +3,10 @@ package org.firstinspires.ftc.teamcode.team.fsm;
 import com.qualcomm.robotcore.hardware.DcMotorEx;
 
 import org.firstinspires.ftc.teamcode.team.MotorHelper;
+import org.firstinspires.ftc.teamcode.team.config.ShooterConfig;
 
 public class ShotgunFSM {
 
-    private final DarienOpModeFSM opmode;
     private final MotorHelper MotorHelper;
     private final double SHOT_GUN_POWER_UP;
     private final double SHOT_GUN_POWER_UP_FAR;
@@ -21,11 +21,10 @@ public class ShotgunFSM {
 
     private State current = State.OFF;
 
-    public ShotgunFSM(double powerlow, double powerhigh, DcMotorEx motor, DarienOpModeFSM opmode, MotorHelper motorHelper) {
+    public ShotgunFSM(double powerlow, double powerhigh, DcMotorEx motor, MotorHelper motorHelper) {
         this.SHOT_GUN_POWER_UP = powerlow;
         this.SHOT_GUN_POWER_UP_FAR = powerhigh;
         this.shotgunMotor = motor;
-        this.opmode = opmode;
         MotorHelper = motorHelper;
     }
 
@@ -55,20 +54,20 @@ public class ShotgunFSM {
         //shotgunMotor.setVelocity(opmode.getTicksPerSecond(opmode.SHOT_GUN_POWER_UP_RPM));
         pidOutput = MotorHelper.pidRunWithEncoder(
                 shotgunMotor,
-                opmode.SHOT_GUN_PGAIN,
-                opmode.SHOT_GUN_PGAIN2,
-                opmode.SHOT_GUN_IGAIN,
+                ShooterConfig.SHOT_GUN_PGAIN,
+                ShooterConfig.SHOT_GUN_PGAIN2,
+                ShooterConfig.SHOT_GUN_IGAIN,
                 power,
-                opmode.SHOT_GUN_PDUTY_MIN,
-                opmode.SHOT_GUN_PDUTY_MAX,
-                opmode.SHOT_GUN_IDUTY_MIN,
-                opmode.SHOT_GUN_IDUTY_MAX,
+                ShooterConfig.SHOT_GUN_PDUTY_MIN,
+                ShooterConfig.SHOT_GUN_PDUTY_MAX,
+                ShooterConfig.SHOT_GUN_IDUTY_MIN,
+                ShooterConfig.SHOT_GUN_IDUTY_MAX,
                 pidOutput[1],
-                opmode.SHOT_GUN_POWER_MIN,
-                opmode.SHOT_GUN_POWER_MAX,
-                opmode.SHOT_GUN_GAIN,
-                opmode.SHOT_GUN_MIN_RPM,
-                opmode.SHOT_GUN_MAX_RPM,
+                ShooterConfig.SHOT_GUN_POWER_MIN,
+                ShooterConfig.SHOT_GUN_POWER_MAX,
+                ShooterConfig.SHOT_GUN_GAIN,
+                ShooterConfig.SHOT_GUN_MIN_RPM,
+                ShooterConfig.SHOT_GUN_MAX_RPM,
                 0,
                 true
         );
@@ -85,20 +84,20 @@ public class ShotgunFSM {
         //shotgunMotor.setVelocity(opmode.getTicksPerSecond(power));
         pidOutput = MotorHelper.pidRunWithEncoder(
                 shotgunMotor,
-                opmode.SHOT_GUN_PGAIN,
-                opmode.SHOT_GUN_PGAIN2,
-                opmode.SHOT_GUN_IGAIN,
+                ShooterConfig.SHOT_GUN_PGAIN,
+                ShooterConfig.SHOT_GUN_PGAIN2,
+                ShooterConfig.SHOT_GUN_IGAIN,
                 power,
-                opmode.SHOT_GUN_PDUTY_MIN,
-                opmode.SHOT_GUN_PDUTY_MAX,
-                opmode.SHOT_GUN_IDUTY_MIN,
-                opmode.SHOT_GUN_IDUTY_MAX,
+                ShooterConfig.SHOT_GUN_PDUTY_MIN,
+                ShooterConfig.SHOT_GUN_PDUTY_MAX,
+                ShooterConfig.SHOT_GUN_IDUTY_MIN,
+                ShooterConfig.SHOT_GUN_IDUTY_MAX,
                 pidOutput[1],
-                opmode.SHOT_GUN_POWER_MIN,
-                opmode.SHOT_GUN_POWER_MAX,
-                opmode.SHOT_GUN_GAIN,
-                opmode.SHOT_GUN_MIN_RPM,
-                opmode.SHOT_GUN_MAX_RPM,
+                ShooterConfig.SHOT_GUN_POWER_MIN,
+                ShooterConfig.SHOT_GUN_POWER_MAX,
+                ShooterConfig.SHOT_GUN_GAIN,
+                ShooterConfig.SHOT_GUN_MIN_RPM,
+                ShooterConfig.SHOT_GUN_MAX_RPM,
                 0,
                 true
         );

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/TeleOpFSM.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/TeleOpFSM.java
@@ -8,6 +8,10 @@ import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 import com.bylazar.configurables.annotations.Configurable;
 
 import android.annotation.SuppressLint;
+import org.firstinspires.ftc.teamcode.team.config.AutoConfig;
+import org.firstinspires.ftc.teamcode.team.config.DriveConfig;
+import org.firstinspires.ftc.teamcode.team.config.ShooterConfig;
+import org.firstinspires.ftc.teamcode.team.config.VisionConfig;
 import org.firstinspires.ftc.teamcode.team.core.AutoParkCoordinator;
 import org.firstinspires.ftc.teamcode.team.core.DriveControlCoordinator;
 import org.firstinspires.ftc.teamcode.team.core.IntakeCoordinator;
@@ -24,15 +28,6 @@ import org.firstinspires.ftc.teamcode.team.services.LocalizationService;
 @Config
 @Configurable
 public class TeleOpFSM extends DarienOpModeFSM {
-
-    // INSTANCES
-    // follower is inherited from DarienOpModeFSM
-    // TUNING CONSTANTS
-    public static double ROTATION_SCALE = 0.5;
-    public static double SPEED_SCALE = 1.0;
-    public static double SPEED_SCALE_TURN = 0.8;
-    public static double INPUT_EXPONENT = 3.0; // 1.0=linear, 2.0=squared, 3.0=cubed (preserves sign)
-    public static double SHOOT_POWER_SELECT_STICK_THRESHOLD = 0.05;
 
     // VARIABLES
     private ShotgunPowerLevel shotgunPowerLatch = ShotgunPowerLevel.OFF;
@@ -52,10 +47,6 @@ public class TeleOpFSM extends DarienOpModeFSM {
     // AUTO-PARK STATE
     private boolean isAutoParking = false;
     private double autoParkStartTime = 0;
-    private static final double AUTO_PARK_STICK_DEADZONE = 0.1; // stick threshold to cancel auto-park
-    public static double DEADZONE = 0.1;
-
-
     @Override
     public void initControls() {
         super.initControls();
@@ -73,9 +64,9 @@ public class TeleOpFSM extends DarienOpModeFSM {
         turretVisionCoordinator = new TurretVisionCoordinator(
                 aprilTagService,
                 turretFSM,
-                APRILTAG_ID_GOAL_BLUE,
-                APRILTAG_ID_GOAL_RED,
-                CAMERA_FALLBACK_TIMEOUT_MS
+                VisionConfig.APRILTAG_ID_GOAL_BLUE,
+                VisionConfig.APRILTAG_ID_GOAL_RED,
+                VisionConfig.CAMERA_FALLBACK_TIMEOUT_MS
         );
     }
 
@@ -95,12 +86,12 @@ public class TeleOpFSM extends DarienOpModeFSM {
         LocalizationService.SeedResult seedResult = localizationService.seedTeleOpPose(
                 autoAlliance,
                 preferencesService,
-                HUMAN_PLAYER_RED_X,
-                HUMAN_PLAYER_RED_Y,
-                HUMAN_PLAYER_BLUE_X,
-                HUMAN_PLAYER_BLUE_Y,
-                ROBOT_CENTER_OFFSET_X,
-                ROBOT_CENTER_OFFSET_Y
+                AutoConfig.HUMAN_PLAYER_RED_X,
+                AutoConfig.HUMAN_PLAYER_RED_Y,
+                AutoConfig.HUMAN_PLAYER_BLUE_X,
+                AutoConfig.HUMAN_PLAYER_BLUE_Y,
+                DriveConfig.ROBOT_CENTER_OFFSET_X,
+                DriveConfig.ROBOT_CENTER_OFFSET_Y
         );
 
         if (seedResult.loadedFromAuto) {
@@ -132,8 +123,8 @@ public class TeleOpFSM extends DarienOpModeFSM {
                     gamepad1.left_stick_x,
                     gamepad1.left_stick_y,
                     gamepad1.right_stick_x,
-                    AUTO_PARK_STICK_DEADZONE,
-                    AUTO_PARK_TIMEOUT,
+                    AutoConfig.AUTO_PARK_STICK_DEADZONE,
+                    AutoConfig.AUTO_PARK_TIMEOUT,
                     follower,
                     telemetry,
                     shotgunPowerLatch
@@ -148,11 +139,11 @@ public class TeleOpFSM extends DarienOpModeFSM {
                     gamepad1.left_stick_y,
                     gamepad1.left_stick_x,
                     gamepad1.right_stick_x,
-                    DEADZONE,
-                    INPUT_EXPONENT,
-                    SPEED_SCALE,
-                    SPEED_SCALE_TURN,
-                    ROTATION_SCALE,
+                    DriveConfig.DRIVE_DEADZONE,
+                    DriveConfig.INPUT_EXPONENT,
+                    DriveConfig.SPEED_SCALE,
+                    DriveConfig.SPEED_SCALE_TURN,
+                    DriveConfig.ROTATION_SCALE,
                     follower
             );
 
@@ -199,13 +190,13 @@ public class TeleOpFSM extends DarienOpModeFSM {
                     getRuntime(),
                     autoParkStartTime,
                     autoAlliance,
-                    PARK_RED_X,
-                    PARK_RED_Y,
-                    PARK_RED_H_DEG,
-                    PARK_BLUE_X,
-                    PARK_BLUE_Y,
-                    PARK_BLUE_H_DEG,
-                    AUTO_PARK_POWER,
+                    AutoConfig.PARK_RED_X,
+                    AutoConfig.PARK_RED_Y,
+                    AutoConfig.PARK_RED_H_DEG,
+                    AutoConfig.PARK_BLUE_X,
+                    AutoConfig.PARK_BLUE_Y,
+                    AutoConfig.PARK_BLUE_H_DEG,
+                    AutoConfig.AUTO_PARK_POWER,
                     follower,
                     intakeFSM,
                     shotgunFSM,
@@ -224,18 +215,18 @@ public class TeleOpFSM extends DarienOpModeFSM {
                     gamepad2.rightBumperWasPressed(),
                     gamepad2.rightBumperWasReleased(),
                     gamepad2.right_stick_y,
-                    SHOOT_POWER_SELECT_STICK_THRESHOLD
+                    ShooterConfig.SHOOT_POWER_SELECT_STICK_THRESHOLD
             );
 
             odometryResetCoordinator.tryResetToHumanPlayerPosition(
                     gamepad1.dpadUpWasPressed(),
                     autoAlliance,
-                    HUMAN_PLAYER_RED_X,
-                    HUMAN_PLAYER_RED_Y,
-                    HUMAN_PLAYER_BLUE_X,
-                    HUMAN_PLAYER_BLUE_Y,
-                    ROBOT_CENTER_OFFSET_X,
-                    ROBOT_CENTER_OFFSET_Y,
+                    AutoConfig.HUMAN_PLAYER_RED_X,
+                    AutoConfig.HUMAN_PLAYER_RED_Y,
+                    AutoConfig.HUMAN_PLAYER_BLUE_X,
+                    AutoConfig.HUMAN_PLAYER_BLUE_Y,
+                    DriveConfig.ROBOT_CENTER_OFFSET_X,
+                    DriveConfig.ROBOT_CENTER_OFFSET_Y,
                     localizationService,
                     telemetry
             );
@@ -280,9 +271,9 @@ public class TeleOpFSM extends DarienOpModeFSM {
                     shootingPowerMode,
                     shotgunPowerLatch,
                     robotY,
-                    SHOOTING_POWER_ODOMETRY_Y_THRESHOLD,
+                    ShooterConfig.SHOOTING_POWER_ODOMETRY_Y_THRESHOLD,
                     gamepad2.right_stick_y,
-                    SHOOT_POWER_SELECT_STICK_THRESHOLD,
+                    ShooterConfig.SHOOT_POWER_SELECT_STICK_THRESHOLD,
                     gamepad2.rightStickButtonWasPressed(),
                     gamepad2.a
             );
@@ -292,8 +283,8 @@ public class TeleOpFSM extends DarienOpModeFSM {
             shooterPowerCoordinator.applyRequestedPower(
                     shotgunFSM,
                     shotgunPowerLatch,
-                    SHOT_GUN_POWER_UP_RPM,
-                    SHOT_GUN_POWER_UP_FAR_RPM_TELEOP,
+                    ShooterConfig.SHOT_GUN_POWER_UP_RPM,
+                    ShooterConfig.SHOT_GUN_POWER_UP_FAR_RPM_TELEOP,
                     telemetry
             );
             telemetryCoordinator.addLoopTelemetry(
@@ -304,7 +295,7 @@ public class TeleOpFSM extends DarienOpModeFSM {
                     turretFSM,
                     shootingPowerMode.toString(),
                     shotgunPowerLatch.toString(),
-                    ejectionMotor.getVelocity() * 60 / TICKS_PER_ROTATION,
+                    ejectionMotor.getVelocity() * 60 / DriveConfig.TICKS_PER_ROTATION,
                     ejectionMotor.getPower(),
                     ejectionMotor.getVelocity(),
                     autoAlliance,
@@ -313,11 +304,11 @@ public class TeleOpFSM extends DarienOpModeFSM {
                     robotY,
                     robotHeadingRadians,
                     isAutoParking,
-                    PARK_RED_X,
-                    PARK_RED_Y,
-                    PARK_BLUE_X,
-                    PARK_BLUE_Y,
-                    AUTO_PARK_TIMEOUT,
+                    AutoConfig.PARK_RED_X,
+                    AutoConfig.PARK_RED_Y,
+                    AutoConfig.PARK_BLUE_X,
+                    AutoConfig.PARK_BLUE_Y,
+                    AutoConfig.AUTO_PARK_TIMEOUT,
                     autoParkStartTime,
                     getRuntime()
             );

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/TurretFSM.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/fsm/TurretFSM.java
@@ -1,13 +1,12 @@
 package org.firstinspires.ftc.teamcode.team.fsm;
 
-import com.acmerobotics.dashboard.config.Config;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 import com.qualcomm.robotcore.hardware.Servo;
 
 import org.firstinspires.ftc.robotcore.external.Telemetry;
+import org.firstinspires.ftc.teamcode.team.config.TurretConfig;
 import org.firstinspires.ftc.teamcode.team.subsystems.SubsystemLifecycle;
 
-@Config
 public class TurretFSM implements SubsystemLifecycle {
 
     public enum TurretStates {MANUAL, CAMERA, ODOMETRY}
@@ -23,31 +22,6 @@ public class TurretFSM implements SubsystemLifecycle {
     public static final int FIVE_ROTATION_SERVO_SPAN_DEG = 1800; // Degrees of rotation (5-rotation goBILDA servo)
 
     /**
-     * Turret gear reduction ratio (input:output).
-     *
-     * A gear reduction of N:1 means the servo (input) must turn N times for the
-     * turret (output) to turn once.  Equivalently, one full servo sweep of 1800°
-     * produces  1800 / N  degrees of turret rotation.
-     *
-     * History:
-     *   6.0  – original code assumption (gave 1800/6 = 300 °/unit — turret overshot)
-     *   5.0  – CAD-specified ratio       (gives 1800/5 = 360 °/unit)
-     *   ~4.55 – tape-measured on robot   (gives 1800/4.55 ≈ 395.6 °/unit)
-     *   5.8  – field-tuned 3/3/2026      (gives 1800/5.8 ≈ 310.3 °/unit — aims on target)
-     *
-     * This is a public static (not final) so it can be tuned live via FTC Dashboard.
-     *
-     * HOW TO TUNE:
-     *   If the turret OVERSHOOTS (aims too far left when pointing left, too far
-     *   right when pointing right), the real ratio is LOWER than the current value
-     *   → DECREASE this number.
-     *
-     *   If the turret UNDERSHOOTS (doesn't turn far enough), the real ratio is
-     *   HIGHER → INCREASE this number.
-     */
-    public static double TURRET_GEAR_RATIO = 5.8;
-
-    /**
      * Returns the effective turret degrees of rotation per full servo unit (0.0→1.0).
      * Recomputed from the live TURRET_GEAR_RATIO every call so FTC Dashboard
      * changes take effect immediately.
@@ -59,40 +33,12 @@ public class TurretFSM implements SubsystemLifecycle {
      * ratio 4.55 → 1800/4.55 ≈ 395.6 °/unit  (tape)
      */
     private static double turretDegPerServoUnit() {
-        return (double) FIVE_ROTATION_SERVO_SPAN_DEG / TURRET_GEAR_RATIO;
+        return (double) FIVE_ROTATION_SERVO_SPAN_DEG / TurretConfig.TURRET_GEAR_RATIO;
     }
 
-    // HARDWARE TUNING CONSTANTS
-    public static double TURRET_ROTATION_INCREMENT = 0.001;
-    public static double TURRET_ROTATION_INCREMENT_FAST = 0.003;
-    public static double TURRET_POSITION_CENTER = 0.5;
-    public static double TURRET_OFFSET_DEG_RED = 1.0;
-    public static double TURRET_OFFSET_DEG_BLUE = -3.0;
-    /**
-     * Distance (inches) from the robot's odometry center of rotation to the turret pivot,
-     * measured along the robot's forward axis. Negative = toward the rear of the robot.
-     * Corrects the parallax aiming error that grows as the robot turns away from the goal.
-     */
-    public static double TURRET_PIVOT_OFFSET_INCHES = -1.5;
-
-    /**
-     * Distance (inches) from the robot's odometry center of rotation to the turret pivot,
-     * measured perpendicular to the robot's forward axis (i.e. sideways).
-     * Positive = turret pivot is to the LEFT of center, Negative = to the RIGHT.
-     * Corrects a lateral parallax error that causes heading-dependent aiming drift
-     * (the turret aims too far right at some headings and too far left at others).
-     */
-    public static double TURRET_PIVOT_OFFSET_LATERAL_INCHES = 0;
-
-    // Turret range of motion in turret degrees (physically measurable on the robot).
-    // Positive = CCW from center (left), Negative = CW from center (right).
-    // Change these when hardware changes; servo clamp limits are derived automatically.
-    public static double TURRET_MAX_DEG_LEFT = 150.0;  // degrees CCW from center
-    public static double TURRET_MAX_DEG_RIGHT = 180.0;  // degrees CW  from center
-
     // DYNAMIC VARIABLES
-    private double TURRET_SERVO_POSITION_MAX_LEFT = TURRET_POSITION_CENTER + 0.1; // Increases counter clockwise
-    private double TURRET_SERVO_POSITION_MAX_RIGHT = TURRET_POSITION_CENTER - 0.1; // Decreases clockwise
+    private double TURRET_SERVO_POSITION_MAX_LEFT = TurretConfig.TURRET_POSITION_CENTER + 0.1; // Increases counter clockwise
+    private double TURRET_SERVO_POSITION_MAX_RIGHT = TurretConfig.TURRET_POSITION_CENTER - 0.1; // Decreases clockwise
 
     private double currentTurretPosition;
 
@@ -125,7 +71,7 @@ public class TurretFSM implements SubsystemLifecycle {
      */
     public double getTurretHeading() {
         // (servo - center) * degreesPerUnit gives turret degrees offset from forward
-        return (currentTurretPosition - TURRET_POSITION_CENTER)
+        return (currentTurretPosition - TurretConfig.TURRET_POSITION_CENTER)
                 * turretDegPerServoUnit();
     }
 
@@ -160,11 +106,11 @@ public class TurretFSM implements SubsystemLifecycle {
         //   pivotX = robotX + cos(h) * forward + (-sin(h)) * lateral
         //   pivotY = robotY + sin(h) * forward + cos(h)    * lateral
         double pivotX = robotX
-                + Math.cos(robotHeadingRadians) * TURRET_PIVOT_OFFSET_INCHES
-                - Math.sin(robotHeadingRadians) * TURRET_PIVOT_OFFSET_LATERAL_INCHES;
+                + Math.cos(robotHeadingRadians) * TurretConfig.TURRET_PIVOT_OFFSET_INCHES
+                - Math.sin(robotHeadingRadians) * TurretConfig.TURRET_PIVOT_OFFSET_LATERAL_INCHES;
         double pivotY = robotY
-                + Math.sin(robotHeadingRadians) * TURRET_PIVOT_OFFSET_INCHES
-                + Math.cos(robotHeadingRadians) * TURRET_PIVOT_OFFSET_LATERAL_INCHES;
+                + Math.sin(robotHeadingRadians) * TurretConfig.TURRET_PIVOT_OFFSET_INCHES
+                + Math.cos(robotHeadingRadians) * TurretConfig.TURRET_PIVOT_OFFSET_LATERAL_INCHES;
 
         // Calculate vector from turret pivot to goal
         double deltaX = goalX - pivotX;
@@ -185,7 +131,7 @@ public class TurretFSM implements SubsystemLifecycle {
 
         // Apply fine mechanical trim AFTER normalization.
         // Read the static constant directly so FTC Dashboard changes take effect immediately.
-        double offsetDeg = isBlueAlliance ? TURRET_OFFSET_DEG_BLUE : TURRET_OFFSET_DEG_RED;
+        double offsetDeg = isBlueAlliance ? TurretConfig.TURRET_OFFSET_DEG_BLUE : TurretConfig.TURRET_OFFSET_DEG_RED;
         angleTurretRelativeToRobotRadians += Math.toRadians(offsetDeg);
 
         // Convert to degrees
@@ -208,7 +154,7 @@ public class TurretFSM implements SubsystemLifecycle {
         //   30° left  → 0.5 + 30/310.3 ≈ 0.597
         //   45° left  → 0.5 + 45/310.3 ≈ 0.645
         //   20° right → 0.5 − 20/310.3 ≈ 0.436
-        double servoPosition = TURRET_POSITION_CENTER +
+        double servoPosition = TurretConfig.TURRET_POSITION_CENTER +
                 (angleDegrees / turretDegPerServoUnit());
 
         // Clamp to servo physical limits to prevent damage
@@ -275,7 +221,7 @@ public class TurretFSM implements SubsystemLifecycle {
     public void alignToBearing(double bearingDeg) {
         // Convert a field-relative bearing (degrees) to a servo position.
         // Same math as calculateServoPositionFromAngle but without clamping.
-        double targetServoPos = TURRET_POSITION_CENTER + bearingDeg / turretDegPerServoUnit();
+        double targetServoPos = TurretConfig.TURRET_POSITION_CENTER + bearingDeg / turretDegPerServoUnit();
         if (!Double.isNaN(targetServoPos)) {
             this.setPosition(targetServoPos);
         }
@@ -290,11 +236,11 @@ public class TurretFSM implements SubsystemLifecycle {
     }
 
     public void rotateLeft() {
-        rotateLeft(TURRET_ROTATION_INCREMENT);
+        rotateLeft(TurretConfig.TURRET_ROTATION_INCREMENT);
     }
 
     public void rotateLeftFast() {
-        rotateLeft(TURRET_ROTATION_INCREMENT_FAST);
+        rotateLeft(TurretConfig.TURRET_ROTATION_INCREMENT_FAST);
     }
 
     public void rotateLeft(double rotationIncrement) {
@@ -305,11 +251,11 @@ public class TurretFSM implements SubsystemLifecycle {
     }
 
     public void rotateRight() {
-        rotateRight(TURRET_ROTATION_INCREMENT);
+        rotateRight(TurretConfig.TURRET_ROTATION_INCREMENT);
     }
 
     public void rotateRightFast() {
-        rotateRight(TURRET_ROTATION_INCREMENT_FAST);
+        rotateRight(TurretConfig.TURRET_ROTATION_INCREMENT_FAST);
     }
 
     public void rotateRight(double rotationIncrement) {
@@ -320,7 +266,7 @@ public class TurretFSM implements SubsystemLifecycle {
     }
 
     public void center() {
-        this.setPosition(TURRET_POSITION_CENTER); // set to center position
+        this.setPosition(TurretConfig.TURRET_POSITION_CENTER); // set to center position
     }
 
     public void setOffsetBlue() {
@@ -339,8 +285,8 @@ public class TurretFSM implements SubsystemLifecycle {
      */
     public void updateTurretServoLimits() {
         double degPerUnit = turretDegPerServoUnit();
-        TURRET_SERVO_POSITION_MAX_LEFT = TURRET_POSITION_CENTER + TURRET_MAX_DEG_LEFT / degPerUnit;
-        TURRET_SERVO_POSITION_MAX_RIGHT = TURRET_POSITION_CENTER - TURRET_MAX_DEG_RIGHT / degPerUnit;
+        TURRET_SERVO_POSITION_MAX_LEFT = TurretConfig.TURRET_POSITION_CENTER + TurretConfig.TURRET_MAX_DEG_LEFT / degPerUnit;
+        TURRET_SERVO_POSITION_MAX_RIGHT = TurretConfig.TURRET_POSITION_CENTER - TurretConfig.TURRET_MAX_DEG_RIGHT / degPerUnit;
     }
 
     public void update() {

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/services/AprilTagVisionService.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/team/services/AprilTagVisionService.java
@@ -3,6 +3,7 @@ package org.firstinspires.ftc.teamcode.team.services;
 import org.firstinspires.ftc.robotcore.external.hardware.camera.WebcamName;
 import org.firstinspires.ftc.robotcore.external.hardware.camera.controls.ExposureControl;
 import org.firstinspires.ftc.robotcore.external.hardware.camera.controls.GainControl;
+import org.firstinspires.ftc.teamcode.team.config.VisionConfig;
 import org.firstinspires.ftc.teamcode.team.fsm.DarienOpModeFSM;
 import org.firstinspires.ftc.vision.VisionPortal;
 import org.firstinspires.ftc.vision.apriltag.AprilTagProcessor;
@@ -44,7 +45,7 @@ public class AprilTagVisionService {
 
     /**
      * Builds the AprilTag processor and VisionPortal, then applies the tuned manual
-     * exposure profile from DarienOpModeFSM constants.
+         * exposure profile from VisionConfig constants.
      *
      * <p>Safe to call during initControls() — blocks briefly until streaming or stop.
      */
@@ -66,7 +67,7 @@ public class AprilTagVisionService {
         }
 
         aprilTagService = null;
-        applyTunedExposure(DarienOpModeFSM.APRILTAG_EXPOSURE_MS, DarienOpModeFSM.APRILTAG_GAIN);
+        applyTunedExposure(VisionConfig.APRILTAG_EXPOSURE_MS, VisionConfig.APRILTAG_GAIN);
     }
 
     /**


### PR DESCRIPTION
Changes:
- Add `team/config/DriveConfig.java`, `ShooterConfig.java`, `TurretConfig.java`, `VisionConfig.java`, and `AutoConfig.java`
- Remove tuning constants from `DarienOpModeFSM` and route call sites to the new scoped config classes
- Update `TeleOpFSM`, `ShootingFSM`, `ShotgunFSM`, `ShootArtifactFSM`, `TurretFSM`, `RobotContainer`, `TurretCoordinator`, `TurretVisionCoordinator`, and `AprilTagVisionService`
- Update `ShotgunSpinStep`, `ShotgunSpinFarStep`, and all 8 active autonomous OpModes to use the new config ownership model

Behavior impact:
- intended no runtime behavior change

Verification:
- `./gradlew.bat :TeamCode:assembleDebug` passes
- TeleOp tested manually and checked out
- `RedGoalSide1` followed by TeleOp tested manually and checked out

Before issuing a pull request, please see the contributing page.
